### PR TITLE
Fix removal instruction for Linux

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -39,4 +39,4 @@ To remove iroh from your machine, delete the following directories:
 `~/Library/Application Support/iroh`
 
 ### Linux
-`$XDG_CONFIG_HOME` or `$HOME/.config/iroh`
+`$XDG_CONFIG_HOME/iroh` or `$HOME/.config/iroh`


### PR DESCRIPTION
The removal instructions for Linux are ambiguous, suggesting to either delete iroh's configuration directory (correct) or the full $HOME/.config (which where $XDG_CONFIG_HOME points by default), thus effectively the configuration of all packages using the XDG facility.