### PR TITLE
fix: remove stale install instructions for beetle

### DIFF
--- a/content/docs/beetle/install.md
+++ b/content/docs/beetle/install.md
@@ -10,14 +10,6 @@ section="beetle"
 
 Beetle works on macOS & Linux. Beetle is released as a collection of four binaries with no external dependencies.
 
-## Installing beetle on your laptop
-Run this script to get started:
-```
-curl -fsSL https://sh.iroh.computer/install_laptop.sh | sh
-```
-
-Running this script will put beetle on your laptop. The installer script automatically configures beetle for the laptop environment. We set up a racing gateway so you can cache IPFS content locally, and leave p2p communication off until you explicitly turn it on. You can be on a zoom call with iroh cloud running in the background.
-
 # Package Managers
 Beetle is not available on major package managers.
 


### PR DESCRIPTION
We no longer maintain releases, so having an install script for beetle makes little sense. The canonical way to keep up to date should be build from source for anyone interested in beetle.