### PR TITLE
Fix some titles

### DIFF
--- a/templates/design/layout.html
+++ b/templates/design/layout.html
@@ -47,9 +47,15 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.4.5/themes/satellite-min.css" integrity="sha256-TehzF/2QvNKhGQrrNpoOb2Ck4iGZ1J/DI4pkd2oUsBc=" crossorigin="anonymous">
 
     <title>
-      {% block title %}
-      {{ config.title }}
-      {% endblock title %}
+      {%- block title -%}
+        {% if page.title %}
+          {{ page.title }}
+        {% elif config.title %}
+          {{ config.title }}
+        {% else %}
+        Iroh
+        {% endif %}
+      {%- endblock title -%}
     </title>
 </head>
 <body class="text-irohGray-600 justify-between font-space">

--- a/templates/docs/layout.html
+++ b/templates/docs/layout.html
@@ -48,9 +48,15 @@
 
 
     <title>
-      {% block title %}
-      {{ config.title }}
-      {% endblock title %}
+      {%- block title -%}
+        {% if page.title %}
+          {{ page.title }}
+        {% elif config.title %}
+          {{ config.title }}
+        {% else %}
+        Iroh
+        {% endif %}
+      {%- endblock title -%}
     </title>
 </head>
 <body class="text-irohGray-600 justify-between font-space">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -42,9 +42,15 @@
     <link href="/styles/style.css" rel="stylesheet">
 
     <title>
-      {% block title %}
-      {{ config.title }}
-      {% endblock title %}
+      {%- block title -%}
+        {% if page.title %}
+          {{ page.title }}
+        {% elif config.title %}
+          {{ config.title }}
+        {% else %}
+        Iroh
+        {% endif %}
+      {%- endblock title -%}
     </title>
 </head>
 <body class="bg-irohGray-900 text-irohGray-700 h-screen justify-between font-space">


### PR DESCRIPTION
Currently, the website has a small bug on it's titles:

![image](https://user-images.githubusercontent.com/26233246/229317113-ebf32f22-c245-4757-8438-63dd7743e962.png)

This PR proposes a small change to update it to:

![image](https://user-images.githubusercontent.com/26233246/229317129-dad1a66e-cb90-4862-aa29-85a19caacf1e.png)


:warning: Note: I wasn't able to figure out why, but apparently all the files `_index.md` do not get it's dynamic title, so a default `Iroh` title was added