### PR TITLE
Minify html

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,8 @@ compile_sass = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
+minify_html = true
+
 [markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola


### PR DESCRIPTION
Apparently, the [default config](https://www.getzola.org/documentation/getting-started/configuration/) is `minify_html = false`