### PR TITLE
Improve UI/UX for search results

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -138,3 +138,24 @@ pre table {
   width: 100%;
   border-collapse: collapse;
 }
+
+/* Search engine */
+.ais-Hits.ais-Hits--empty {
+  padding: 1.5rem;
+}
+
+.ais-Hits-item,
+.ais-InfiniteHits-item {
+  padding: 0 !important;
+}
+
+.ais-Hits-item>a,
+.ais-InfiniteHits-item>a {
+  padding: 1.5rem;
+  width: 100%;
+}
+
+.ais-Hits-item>a:hover,
+.ais-Hits-item>a:hover .ais-Highlight-highlighted {
+  font-style: italic;
+}

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1164,6 +1164,23 @@ pre table {
   border-collapse: collapse;
 }
 
+.ais-Hits.ais-Hits--empty {
+  padding: 1.5rem;
+}
+
+.ais-Hits-item, .ais-InfiniteHits-item {
+  padding: 0 !important;
+}
+
+.ais-Hits-item > a, .ais-InfiniteHits-item > a {
+  width: 100%;
+  padding: 1.5rem;
+}
+
+.ais-Hits-item > a:hover, .ais-Hits-item > a:hover .ais-Highlight-highlighted {
+  font-style: italic;
+}
+
 .hover\:cursor-pointer:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
This PR updates:
- The clickable area for search results
- Add small UI feedback on hover (italic font)

Current clickable area:

![image](https://user-images.githubusercontent.com/26233246/229320094-558b233f-8492-4df6-adb9-7557b241666b.png)

This PR (Note the italic text on 3rd line):

![image](https://user-images.githubusercontent.com/26233246/229320160-60fff4c4-4ca0-45ca-b0c2-58b2beb417b5.png)
