### PR TITLE
add install instructions for tea package manager

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -17,7 +17,16 @@ curl -fsSL https://sh.iroh.computer/install.sh | sh
 ```
 
 # Package Managers
-Iroh is not currently available on package managers.
+
+Iroh is available on [tea](https://tea.xyz/) for macOS and Linux. To install, run:
+
+```
+$ curl tea.xyz | sh
+# ^^ installs the tea package manager
+
+$ iroh --help
+# ^^ tea installs iroh automagically!
+```
 
 # Docker
 We don't yet have official docker images for iroh.


### PR DESCRIPTION
Hi there, I found out about iroh from JJ and it looks really cool!

We saw that currently there's no package manager to support `iroh`, so we wanted to change that 😉

[tea](https://github.com/teaxyz/cli) is a new kind of package manager from the creator of Homebrew and we packaged `iroh` up so that anyone using `tea` can easily install and use iroh as well :) 


