### PR TITLE
fill out all `doc_list` examples

### DIFF
--- a/api-code-examples/api.mjs
+++ b/api-code-examples/api.mjs
@@ -9,6 +9,10 @@ const doc = [
       tiqpal5qnrb3idy7g4n7hnh5esex7zu6jtqyuwt6hr4iq2nnlpua
       3ogcanavjfehmoeuf3jkel5pmbv2bpdwybvzt7xzk5sgbub72mia
       njszszvgpziwnxqnsi32nmc7j2czs2rnj3m7czavudurqxld3nbq`,
+      cli: `$ iroh doc list
+      tiqpal5qnrb3idy7g4n7hnh5esex7zu6jtqyuwt6hr4iq2nnlpua
+      3ogcanavjfehmoeuf3jkel5pmbv2bpdwybvzt7xzk5sgbub72mia
+      njszszvgpziwnxqnsi32nmc7j2czs2rnj3m7czavudurqxld3nbq`
     }
   },
   {
@@ -228,25 +232,6 @@ Adding my_txt.txt as /Users/me/my_txt.txt...
 Total: 328 B
 
 Collection: bafkr4ie3xsx3vdsbflainnk6p4xs4h2hq3hdmuasuoflkgybvnsbljb3ke`,
-    }
-  },
-  { 
-    name: 'blob share',
-    description: 'Download data to the running provider\'s database and provide it.',
-    slug: 'blob-share',
-    arguments: [
-      { name: 'hash', required: '', description: 'Hash to get, required unless ticket is specified.' },
-      { name: 'recursive', required: '', description: 'Treat as collection, required unless ticket is specified [possible values: true, false].'},
-      { name: 'peer', required: '', description: 'PublicKey of the provider.' },
-      { name: 'addr', required: '', description: 'Addresses of the provider.' },
-      { name: 'derp-region', required: '', description: 'DERP region ID of the provider.' },
-      { name: 'token', required: '', description: 'Base32-encoded request token to use for authentication, if any.' },
-      { name: 'ticket', required: '', description: 'Base32-encoded ticket to use for fetching.' },
-      { name: 'out', required: '', description: 'Directory in which to save the file(s).' },
-      { name: 'stable', required: '', description: 'If this is set to true, the data will be moved to the output directory, and iroh will assume that it will not change.'}
-    ],
-    examples: {
-      console: `> `,
     }
   },
   { 

--- a/api-code-examples/go/doc-list.go
+++ b/api-code-examples/go/doc-list.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode()
+	if err != nil {
+		// real programs handle errors!
+		panic(err)
+	}
+
+	// create one document
+	doc, err := node.DocNew()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id())
+
+	// create a second document
+	doc, err := node.DocNew()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id())
+
+	// list all your documents
+	docs, err := node.DocList()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Listing all %d documents:\n", len(docs))
+	for _, doc_id := range docs {
+		fmt.Printf("\t%s\n", doc_id.ToString())
+	}
+}

--- a/api-code-examples/python/doc-list.py
+++ b/api-code-examples/python/doc-list.py
@@ -1,0 +1,20 @@
+import iroh
+
+IROH_DATA_DIR = "./iroh-data"
+
+node = iroh.IrohNode(IROH_DATA_DIR)
+print("Started Iroh node: {}".format(node.node_id()))
+
+# create a document
+doc = node.doc_new()
+print("Created doc: {}".format(doc.id()))
+
+# create a second document
+doc = node.doc_new()
+print("Created doc: {}".format(doc.id()))
+
+# list all your documents
+docs = node.doc_list();
+print("List all {} docs:".format(len(docs)))
+for doc in docs:
+    print("\t{}".format(doc.to_string()))

--- a/api-code-examples/rust/doc-list.rs
+++ b/api-code-examples/rust/doc-list.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use futures::StreamExt;
 
 use iroh::{bytes::util::runtime, collection::IrohCollectionParser, node::Node};
+use iroh_sync::store::GetFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,15 +21,27 @@ async fn main() -> Result<()> {
     let node = node.spawn().await?;
     let client = node.client();
 
-    // create a document
-    let doc_0 = client.create_doc().await?;
-    let doc_1 = client.create_doc().await?;
+    // create a document & author
+    let author = client.create_author().await?;
+    let doc = client.create_doc().await?;
 
-    println!("List all docs:");
-    let doc_ids = client.doc_list().await?;
-    for doc_id in doc_ids.into_iter() {
-        println!("\t{doc_id}");
-    }
+    // set the key "key" to "value"
+    let key = b"key";
+    let value = b"value";
+    doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
+    println!("key is set!");
+
+    // read the value back
+    let filter = GetFilter::latest().with_key(key);
+    let entry = doc
+        .get(filter)
+        .await?
+        .next()
+        .await
+        .ok_or_else(|| anyhow!("entry not found"))??;
+    let content = doc.get_content_bytes(&entry).await?;
+
+    println!("value bytes: {:?}", content);
 
     Ok(())
 }

--- a/src/app/docs/api/doc-get/page.mdx
+++ b/src/app/docs/api/doc-get/page.mdx
@@ -133,12 +133,7 @@ func main() {
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 
-use iroh::{
-    collection::IrohCollectionParser,
-    node::Node,
-    bytes::util::runtime,
-};
-use iroh_sync::store::GetFilter;
+use iroh::{bytes::util::runtime, collection::IrohCollectionParser, node::Node};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -150,30 +145,24 @@ async fn main() -> Result<()> {
         .collection_parser(IrohCollectionParser)
         .runtime(&rt)
         .bind_addr("127.0.0.1:0".parse()?);
-    
+
     // start the node & create a client
     let node = node.spawn().await?;
     let client = node.client();
 
-    // create a document & author
-    let author = client.create_author().await?;
-    let doc = client.create_doc().await?;
+    // create a document
+    let doc_0 = client.create_doc().await?;
+    let doc_1 = client.create_doc().await?;
 
-    // set the key "key" to "value"
-    let key = b"key";
-    let value = b"value";
-    doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
-    println!("key is set!");
-
-    // read the value back
-    let filter = GetFilter::latest().with_key(key);
-    let entry = doc.get(filter).await?.next().await.ok_or_else(|| anyhow!("entry not found"))??;
-    let content = doc.get_content_bytes(&entry).await?;
-    
-    println!("value bytes: {:?}", content);
+    println!("List all docs:");
+    let doc_ids = client.doc_list().await?;
+    for doc_id in doc_ids.into_iter() {
+        println!("\t{doc_id}");
+    }
 
     Ok(())
 }
+
 ```
 
 

--- a/src/app/docs/api/doc-list/page.mdx
+++ b/src/app/docs/api/doc-list/page.mdx
@@ -28,5 +28,73 @@ List documents on this node. {{ className: 'lead' }}
       njszszvgpziwnxqnsi32nmc7j2czs2rnj3m7czavudurqxld3nbq
 ```
 
+```python {{ title: 'python' }}
+import iroh
+
+IROH_DATA_DIR = "./iroh-data"
+
+node = iroh.IrohNode(IROH_DATA_DIR)
+print("Started Iroh node: {}".format(node.node_id()))
+
+# create a document
+doc = node.doc_new()
+print("Created doc: {}".format(doc.id()))
+
+# create a second document
+doc = node.doc_new()
+print("Created doc: {}".format(doc.id()))
+
+# list all your documents
+docs = node.doc_list();
+print("List all {} docs:".format(len(docs)))
+for doc in docs:
+    print("\t{}".format(doc.to_string()))
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode()
+	if err != nil {
+		// real programs handle errors!
+		panic(err)
+	}
+
+	// create one document
+	doc, err := node.DocNew()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id())
+
+	// create a second document
+	doc, err := node.DocNew()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id())
+
+	// list all your documents
+	docs, err := node.DocList()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Listing all %d documents:\n", len(docs))
+	for _, doc_id := range docs {
+		fmt.Printf("\t%s\n", doc_id.ToString())
+	}
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/doc-list/page.mdx
+++ b/src/app/docs/api/doc-list/page.mdx
@@ -28,6 +28,13 @@ List documents on this node. {{ className: 'lead' }}
       njszszvgpziwnxqnsi32nmc7j2czs2rnj3m7czavudurqxld3nbq
 ```
 
+```bash {{ title: 'CLI' }}
+$ iroh doc list
+      tiqpal5qnrb3idy7g4n7hnh5esex7zu6jtqyuwt6hr4iq2nnlpua
+      3ogcanavjfehmoeuf3jkel5pmbv2bpdwybvzt7xzk5sgbub72mia
+      njszszvgpziwnxqnsi32nmc7j2czs2rnj3m7czavudurqxld3nbq
+```
+
 ```python {{ title: 'python' }}
 import iroh
 
@@ -92,6 +99,57 @@ func main() {
 	for _, doc_id := range docs {
 		fmt.Printf("\t%s\n", doc_id.ToString())
 	}
+}
+
+```
+
+```rust {{ title: 'rust' }}
+#![cfg(feature = "mem-db")]
+
+use anyhow::{anyhow, Result};
+use futures::StreamExt;
+
+use iroh::{bytes::util::runtime, collection::IrohCollectionParser, node::Node};
+use iroh_sync::store::GetFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // build the node
+    let rt = runtime::Handle::from_currrent(1).unwrap();
+    let db = iroh::baomap::mem::Store::new(rt.clone());
+    let store = iroh_sync::store::memory::Store::default();
+    let node = Node::builder(db, store)
+        .collection_parser(IrohCollectionParser)
+        .runtime(&rt)
+        .bind_addr("127.0.0.1:0".parse()?);
+
+    // start the node & create a client
+    let node = node.spawn().await?;
+    let client = node.client();
+
+    // create a document & author
+    let author = client.create_author().await?;
+    let doc = client.create_doc().await?;
+
+    // set the key "key" to "value"
+    let key = b"key";
+    let value = b"value";
+    doc.set_bytes(author, key.to_vec(), value.to_vec()).await?;
+    println!("key is set!");
+
+    // read the value back
+    let filter = GetFilter::latest().with_key(key);
+    let entry = doc
+        .get(filter)
+        .await?
+        .next()
+        .await
+        .ok_or_else(|| anyhow!("entry not found"))??;
+    let content = doc.get_content_bytes(&entry).await?;
+
+    println!("value bytes: {:?}", content);
+
+    Ok(())
 }
 
 ```


### PR DESCRIPTION
- [x] go
- [x] python
- [x] rust
- [x] console

also removes `blob share` page, since this command does not exist