### PR TITLE
Clean up examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# go
+extern
+iroh_data_dir

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "api-code-examples/go/extern/iroh-ffi"]
+	path = api-code-examples/go/extern/iroh-ffi
+	url = https://github.com/n0-computer/iroh-ffi.git

--- a/api-code-examples/README.md
+++ b/api-code-examples/README.md
@@ -1,0 +1,43 @@
+# iroh API code examples
+
+This directory includes all the code examples that show how to achieve `iroh` cli commands programmatically using rust, golang, and python.
+
+## running the examples
+
+There is a `run_files.sh` bash script that will run all of the python and golang examples. The following sections will describe how to set up the golang and python environments to run the script correctly.
+
+You can also run the individual examples without using the `run_files.sh` script.
+
+### running python
+
+Download python3 and download some way to manage virtual environments. pip will likely come with python, but if not, download pip3 as well.
+
+Navigate into the `python` directory.
+
+Create and activate a virtual environment for this project.
+
+Install iroh:
+`python3 -m pip install iroh`
+
+To run an example, eg for file `author-list.py`:
+`python3 run author-list.py`
+
+### running golang
+
+Download & set up go.
+
+Navigate to the go directory.
+
+Run the following commands:
+```
+$ go get github.com/n0-computer/iroh-ffi/iroh-go/iroh
+$ git submodule add https://github.com/n0-computer/iroh-ffi.git extern/iroh-ffi
+$ make -f extern/iroh-ffi/InstallGo
+$ go mod edit -replace=github.com/n0-computer/iroh-ffi/iroh-go=./extern/iroh-ffi/iroh-go
+```
+
+To run an example, eg for the file `author-list.py`:
+`go run author-list.py`
+
+### running the script
+Once the above are set up, run the `run_files.sh` script to iterate through each go and python file to ensure that the examples work!

--- a/api-code-examples/api.mjs
+++ b/api-code-examples/api.mjs
@@ -3,7 +3,7 @@ const doc = [
   {
     name: 'doc delete',
     description: 'Delete all document entries below a key prefix.',
-    slug: 'doc-del',
+    slug: 'doc-delete',
     arguments: [
       { name: "prefix", necessity: 'required', description: "Prefix to delete. All entries whose key starts with or is equal to the prefix will be deleted" }
     ],
@@ -373,17 +373,6 @@ Collection: bafkr4ie3xsx3vdsbflainnk6p4xs4h2hq3hdmuasuoflkgybvnsbljb3ke`,
       console: `> `,
     }
   },
-  { 
-    name: 'blob validate',
-    description: 'Validate hashes on the running node.',
-    slug: 'blob-validate',
-    arguments: [
-      { name: 'repair', necessity: '', description: 'Repair the store by removing invalid data.' }
-    ],
-    examples: {
-      console: `> `,
-    }
-  }
 ]
 
 const api = {

--- a/api-code-examples/go/author-list.go
+++ b/api-code-examples/go/author-list.go
@@ -12,16 +12,19 @@ func main() {
 		panic(err)
 	}
 
-	if _, err := node.AuthorCreate(); err != nil {
+	author, err := node.AuthorCreate()
+	if err != nil {
 		panic(err)
 	}
+	fmt.Println("Created author:", author.ToString())
 
 	authors, err := node.AuthorList()
 	if err != nil {
 		panic(err)
 	}
 
+	fmt.Println("Authors:")
 	for _, author := range authors {
-		fmt.Println(author.ToString())
+		fmt.Println("\t", author.ToString())
 	}
 }

--- a/api-code-examples/go/author-list.go
+++ b/api-code-examples/go/author-list.go
@@ -3,16 +3,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	if _, err := node.AuthorNew(); err != nil {
+	if _, err := node.AuthorCreate(); err != nil {
 		panic(err)
 	}
 

--- a/api-code-examples/go/author-new.go
+++ b/api-code-examples/go/author-new.go
@@ -3,16 +3,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}

--- a/api-code-examples/go/blob-add.go
+++ b/api-code-examples/go/blob-add.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type addCallback struct {
+}
+
+func (a addCallback) Progress(event *iroh.AddProgress) *iroh.IrohError {
+	switch t := event.Type(); t {
+	case iroh.AddProgressTypeFound:
+		fmt.Println("AddProgress - Found:")
+		found := event.AsFound()
+		fmt.Printf("\tid: %d, name: %s, size: %d\n", found.Id, found.Name, found.Size)
+	case iroh.AddProgressTypeProgress:
+		fmt.Println("AddProgress - Progress:")
+		progress := event.AsProgress()
+		fmt.Printf("\tid: %d, offset: %d\n", progress.Id, progress.Offset)
+	case iroh.AddProgressTypeDone:
+		fmt.Println("AddProgress - Done:")
+		done := event.AsDone()
+		fmt.Printf("\tid: %d, hash: %s\n", done.Id, done.Hash.ToString())
+	case iroh.AddProgressTypeAllDone:
+		fmt.Println("AddProgress - AllDone:")
+		allDone := event.AsAllDone()
+		fmt.Printf("\thash: %s, format: %v, tag: %s\n", allDone.Hash.ToString(), allDone.Format, allDone.Tag.ToString())
+	case iroh.AddProgressTypeAbort:
+		fmt.Println("AddProgress - Abort:")
+		abort := event.AsAbort()
+		fmt.Printf("\terror: %s", abort.Error)
+	default:
+		fmt.Println("Unknown AddProgress event: %v", event)
+		return &iroh.IrohError{}
+	}
+	return nil
+}
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	path, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// when `inPlace` is true, iroh will NOT copy over the files into its
+	// internal database. Only use this option when you know the file will never
+	// move or change
+	inPlace := false
+	// iroh blobs can be "tagged" with human readable names, this creates a tag
+	// automatically
+	tag := iroh.SetTagOptionAuto()
+	// when adding a single file, if you use `iroh.WrapOptionWrap`, you will turn
+	// the single file into a collection with one entry
+	wrap := iroh.WrapOptionNoWrap()
+	// you can use this callback to react to progress updates
+	callback := addCallback{}
+
+	// import the directory, creating one blob for each file, and one metadata
+	// blob that stores the file names for each blob
+	// also creates a 'collection' from the directory, grouping together the
+	// blobs
+
+	err = node.BlobsAddFromPath(path, inPlace, tag, wrap, callback)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"
+	// Created file "tmp/bar"
+	// Created file "tmp/bat"
+	// AddProgress - Found:
+	//    id: 2, name: $HOME/tmp/bar, size: 3
+	// AddProgress - Found:
+	//		id: 0, name: $HOME/tmp/foo, size: 3
+	// AddProgress - Found:
+	//		id: 1, name: $HOME/tmp/bat, size: 3
+	// AddProgress - Progress:
+	//		id: 1, offset: 3
+	// AddProgress - Done:
+	//		id: 1, hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4
+	// AddProgress - Progress:
+	//		id: 2, offset: 3
+	// AddProgress - Progress:
+	//		id: 0, offset: 3
+	// AddProgress - Done:
+	//		id: 2, hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu
+	// AddProgress - Done:
+	//		id: 0, hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e
+	// AddProgress - AllDone:
+	//		hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim, format: 2, tag: "auto-2023-12-09T17:37:42.432Z"
+	// Removed dir 'tmp'
+}

--- a/api-code-examples/go/blob-list-blobs.go
+++ b/api-code-examples/go/blob-list-blobs.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	b := []byte("hello world!")
+	tag := iroh.SetTagOptionAuto()
+
+	// add blob
+	outcome, err := node.BlobsAddBytes(b, tag)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Added blob %s (%d bytes)\n", outcome.Hash.ToString(), outcome.Size)
+
+	fmt.Println("blobs list:")
+
+	blobs, err := node.BlobsList()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, hash := range blobs {
+		fmt.Println("\t", hash.ToString())
+	}
+
+	// Output:
+	// Added blob bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu (12 bytes)
+	// blobs list:
+	//  bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu
+	//
+	//  (may contain additional hashes if you have previously added content to your node)
+}

--- a/api-code-examples/go/blob-list-collections.go
+++ b/api-code-examples/go/blob-list-collections.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type addCallback struct {
+	hashCh chan iroh.Hash
+}
+
+func (a addCallback) Progress(event *iroh.AddProgress) *iroh.IrohError {
+	if event.Type() == iroh.AddProgressTypeAllDone {
+		allDone := event.AsAllDone()
+		a.hashCh <- *allDone.Hash
+	}
+	return nil
+}
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	path, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// when `inPlace` is true, iroh will NOT copy over the files into its
+	// internal database. Only use this option when you know the file will never
+	// move or change
+	inPlace := false
+	// iroh blobs can be "tagged" with human readable names, this creates a tag
+	// automatically
+	tag := iroh.SetTagOptionNamed(iroh.TagFromString("my_collection"))
+	// when adding a single file, if you use `iroh.WrapOptionWrap`, you will turn
+	// the single file into a collection with one entry
+	wrap := iroh.WrapOptionNoWrap()
+	// you can use this callback to react to progress updates
+	hashCh := make(chan iroh.Hash, 1)
+	callback := addCallback{hashCh}
+
+	// import the directory, creating one blob for each file, and one metadata
+	// blob that stores the file names for each blob
+	// also creates a 'collection' from the directory, grouping together the
+	// blobs
+
+	err = node.BlobsAddFromPath(path, inPlace, tag, wrap, callback)
+	if err != nil {
+		panic(err)
+	}
+
+	hash := <-hashCh
+
+	fmt.Println("Added collection", hash.ToString())
+
+	fmt.Println("collections list:")
+
+	collRes, err := node.BlobsListCollections()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, res := range collRes {
+		fmt.Printf("\thash: %s tag: %s\n", res.Hash.ToString(), res.Tag.ToString())
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"
+	// Created file "tmp/bar"
+	// Created file "tmp/bat"
+	// AllDone
+	// Added collection bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim
+	// collections list:
+	// 	hash:bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim tag:"my_collection"
+	// Removed dir 'tmp'
+	//
+	// (may contain additional collections if you have previously added content to your node)
+}

--- a/api-code-examples/go/blob-list-incomplete-blobs.go
+++ b/api-code-examples/go/blob-list-incomplete-blobs.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// typically only happens if you have not finished syncing or interrupted
+	// a download
+	incompletes, err := node.BlobsListIncomplete()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Incomplete blobs:")
+	for _, res := range incompletes {
+		fmt.Printf("\thash: %s size: %s expected size: %d\n", res.Hash.ToString(), res.Size, res.ExpectedSize)
+	}
+
+	// Output:
+	// Incomplete blobs:
+}

--- a/api-code-examples/go/doc-delete.go
+++ b/api-code-examples/go/doc-delete.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		// real programs handle errors!
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Inserted %s\n", hash.ToString())
+
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Keys:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := doc.ReadToBytes(entry)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	fmt.Printf("Removing entry for author %s and prefix %s.\n", author.ToString(), string(key))
+	// removes all entries from that author and with the prefix "key"
+	num_removed, err := doc.Delete(author, key)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Removed %d entry\n", num_removed)
+
+	// get all the entries with default filtering and sorting
+	entries, err = doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Keys:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := doc.ReadToBytes(entry)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	// Output:
+	// Created author x2xi6sosy2yafpj3xx6zzocvfxzzdrwlkhaqew5v4pcccg2rtesa
+	// Created document bq3ioxh7licvicknhuxl2in24qagzlewoaotgvm3xbr6nxwrv7ea
+	// Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+	// Keys:
+	// "go" : "says hello" (hash: bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte)
+	// Removing entry for author x2xi6sosy2yafpj3xx6zzocvfxzzdrwlkhaqew5v4pcccg2rtesa and prefix go.
+	// Removed 1 entry
+	// Keys:
+}

--- a/api-code-examples/go/doc-drop.go
+++ b/api-code-examples/go/doc-drop.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	fmt.Println("List of docs and their capabilities (0-Read, 1-Write):")
+
+	// returns an array of `iroh.NamespaceAndCapability`s
+	// NamespaceId is the Doc's Id
+	// and the Capability is whether you have read or write access to the doc
+	ns, err := node.DocList()
+	if err != nil {
+		panic(err)
+	}
+	for i := 0; i < len(ns); i++ {
+		fmt.Printf("\t%s\t%v\n", ns[i].Namespace.ToString(), ns[i].Capability)
+	}
+
+	err = node.DocDrop(doc.Id())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Dropped document %s\n", doc.Id().ToString())
+
+	fmt.Println("List of docs and their capabilities (0-Read, 1-Write):")
+	ns, err = node.DocList()
+	if err != nil {
+		panic(err)
+	}
+	// list no longer contains the dropped doc
+	for i := 0; i < len(ns); i++ {
+		fmt.Printf("\t%s\t%v\n", ns[i].Namespace.ToString(), ns[i].Capability)
+	}
+
+	// Output
+	// Created document cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha
+	// List of docs and their capabilities (0-Read, 1-Write):
+	//   cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha	1
+	// Dropped document cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha
+	// List of docs and their capabilities (0-Read, 1-Write):
+}

--- a/api-code-examples/go/doc-export.go
+++ b/api-code-examples/go/doc-export.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	root, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir", root)
+
+	// create file
+	path := filepath.Join("tmp", "hello_world")
+	f, err := os.Create(path)
+	if err != nil {
+		panic(err)
+	}
+	_, err = f.WriteString("Hello World!")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created file \"hello_world\"\n")
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	prefix := "import-example"
+
+	// import the file
+	path, err = filepath.Abs(filepath.Join("tmp", "hello_world"))
+	if err != nil {
+		panic(err)
+	}
+	// create a key from the path, use the `iroh.PathToKey` function to ensure
+	// that we strip the root correctly, and add any prefix we want to add for
+	// organizational purposes
+	key, err := iroh.PathToKey(path, &prefix, &root)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("key: %s\n", key)
+	err = doc.ImportFile(author, key, path, false, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// export the file
+	// get the entry via an exact author and key
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+	// create an export directory
+	if err := os.Mkdir("export", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("export")
+		fmt.Println("Removed dir 'export'")
+	}()
+	root, err = filepath.Abs(filepath.Join("export"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("root:", root)
+
+	// create the export path from the key, prefix, and directory location
+	// this allows you to strip whatever prefix you have added to the key, and
+	// add the absolute path to the relative path we used to create the key.
+	// KeyToPath is the inverse of PathToKey
+	exportPath, err := iroh.KeyToPath(key, &prefix, &root)
+	if err != nil {
+		panic(err)
+	}
+	// export the entry
+	err = doc.ExportFile(*entry, exportPath, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// open the exported file & print the contents
+	content, err := ioutil.ReadFile(exportPath)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("file %s: %q\n", exportPath, content)
+
+	// Output:
+	// Created $HOME/tmp
+	// Created file "hello_world"
+	// Created author hr6p3rrvp6ywlsitgd4djxzz67uhrb7eg2gho4zogb4e5rkpan5a
+	// Created document in66kpmbqedchn6rkzvq3ri4omren5mkid3cecjmakj23ofefpqa
+	// key: import-examplehello_world
+	// root: $HOME/export
+	// file $HOME/export/hello_world: "Hello World!"
+	// Removed dir 'export'
+	// Removed dir 'tmp'
+}

--- a/api-code-examples/go/doc-get.go
+++ b/api-code-examples/go/doc-get.go
@@ -13,25 +13,34 @@ func main() {
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Created author %s\n", author.ToString())
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	hash, err := doc.SetBytes(author, []byte("go"), []byte("says hello"))
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Inserted %s\n", hash.ToString())
 
-	content, err := doc.GetContentBytes(hash)
+	// returns a pointer to an entry
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+
+	// dereference the pointer to the entry once you know doc.GetExact did not
+	// return an error
+	content, err := (*entry).ContentBytes(doc)
 	if err != nil {
 		panic(err)
 	}

--- a/api-code-examples/go/doc-get.go
+++ b/api-code-examples/go/doc-get.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)

--- a/api-code-examples/go/doc-import.go
+++ b/api-code-examples/go/doc-import.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	root, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	prefix := "import-example"
+	// import the files
+	for _, fileName := range fileNames {
+		path, err := filepath.Abs(filepath.Join("tmp", fileName))
+		if err != nil {
+			panic(err)
+		}
+		// create a key from the path, use the `iroh.PathToKey` function to ensure
+		// that we strip the root correctly, and add any prefix we want to add for
+		// organizational purposes
+		key, err := iroh.PathToKey(path, &prefix, &root)
+		if err != nil {
+			panic(err)
+		}
+
+		doc.ImportFile(author, key, path, false, nil)
+	}
+
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("One entry for each file:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := entry.ContentBytes(doc)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%s: %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"Created file "tmp/bar"Created file "tmp/bat"Created author kup6o2nnubm67rupuzo4mxjjwafpo6fbvhjjfjxdmvvm337i2txq
+	// Created document rezwubpa2pxt5ikvrwr65oifq5csnz6h3eeq7l2yrkfewo6dji2a
+	// One entry for each file:
+	// import-examplebar: "bar" (hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu)
+	// import-examplebat: "bat" (hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4)
+	// import-examplefoo: "foo" (hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e)
+	// Removed dir 'tmp'
+}

--- a/api-code-examples/go/doc-join.go
+++ b/api-code-examples/go/doc-join.go
@@ -3,15 +3,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 // you'll need to get a ticket from somewhere, see the `doc share` command documentation
-// for details. This ticket will fail to join, but is a valid ticket.
-const ticketString = "sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg"
+// for details.
+
+const ticketString = "docaaqjjfgbzx2ry4zpaoujdppvqktgvfvpxgqubkghiialqovv7z4wosqbebpvjjp2tywajvg6unjza6dnugkalg4srmwkcucmhka7mgy4r3aa4aibayaeusjsjlcfoagavaa4xrcxaetag4aaq45mxvqaaaaaaaaadiu4kvybeybxaaehhlf5mdenfufmhk7nixcvoajganyabbz2zplgbno2vsnuvtkpyvlqcjqdoaaioowl22k3fc26qjx4ot6fk4"
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
@@ -26,5 +27,5 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Joined doc: %s", doc.Id())
+	fmt.Println("Joined doc:", doc.Id().ToString())
 }

--- a/api-code-examples/go/doc-join.go
+++ b/api-code-examples/go/doc-join.go
@@ -9,7 +9,7 @@ import (
 // you'll need to get a ticket from somewhere, see the `doc share` command documentation
 // for details.
 
-const ticketString = "docaaqjjfgbzx2ry4zpaoujdppvqktgvfvpxgqubkghiialqovv7z4wosqbebpvjjp2tywajvg6unjza6dnugkalg4srmwkcucmhka7mgy4r3aa4aibayaeusjsjlcfoagavaa4xrcxaetag4aaq45mxvqaaaaaaaaadiu4kvybeybxaaehhlf5mdenfufmhk7nixcvoajganyabbz2zplgbno2vsnuvtkpyvlqcjqdoaaioowl22k3fc26qjx4ot6fk4"
+const ticketString = "docaaa7qg6afc6zupqzfxmu5uuueaoei5zlye7a4ahhrfhvzjfrfewozgybl5kkl6u6fqcnjxvdkoihq3nbsqczxeulfsqvatb2qh3bwheoyahacitior2ha4z2f4xxk43fgewtcltemvzhaltjojxwqltomv2ho33snmxc6biajjeteswek4ambkabzpcfoajganyabbz2zplaaaaaaaaaagrjyvlqcjqdoaaioowl2ygi2likyov62rofk4asma3qacdtvs6whqsdbizopsefrrkx"
 
 func main() {
 	node, err := iroh.NewIrohNode("iroh_data_dir")

--- a/api-code-examples/go/doc-keys.go
+++ b/api-code-examples/go/doc-keys.go
@@ -40,7 +40,7 @@ func main() {
 	for _, entry := range entries {
 		key := entry.Key()
 		hash := entry.ContentHash()
-		content, err := doc.ReadToBytes(entry)
+		content, err := entry.ContentBytes(doc)
 		if err != nil {
 			panic(err)
 		}

--- a/api-code-examples/go/doc-keys.go
+++ b/api-code-examples/go/doc-keys.go
@@ -3,25 +3,25 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	for i, key := range []string{"a", "b", "c"} {
 		if _, err := doc.SetBytes(author, []byte(key), []byte(fmt.Sprintf("%d", i))); err != nil {
@@ -29,18 +29,22 @@ func main() {
 		}
 	}
 
-	keys, err := doc.Keys()
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Println("Keys:")
-	for _, key := range keys {
-		content, err := doc.GetContentBytes(key)
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := doc.ReadToBytes(entry)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("%q : %q (hash: %s)\n", string(key.Key()), string(content), key.Hash().ToString())
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
 	}
 	// Output:
 	// Created document 7hgonoxdjzlwtuicfyou24l5nhv3bmvzhyeq6v2er66ekrpvhotq

--- a/api-code-examples/go/doc-list.go
+++ b/api-code-examples/go/doc-list.go
@@ -3,29 +3,29 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
 	// create one document
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	// create a second document
-	doc, err := node.DocNew()
+	doc, err = node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	// list all your documents
 	docs, err := node.DocList()
@@ -34,7 +34,8 @@ func main() {
 	}
 
 	fmt.Printf("Listing all %d documents:\n", len(docs))
-	for _, doc_id := range docs {
-		fmt.Printf("\t%s\n", doc_id.ToString())
+	// doc ids are also called "NamespaceIds"
+	for _, namespaceAndCapability := range docs {
+		fmt.Printf("\t%s\n", namespaceAndCapability.Namespace.ToString())
 	}
 }

--- a/api-code-examples/go/doc-new.go
+++ b/api-code-examples/go/doc-new.go
@@ -3,19 +3,19 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 }

--- a/api-code-examples/go/doc-set.go
+++ b/api-code-examples/go/doc-set.go
@@ -40,7 +40,7 @@ func main() {
 
 	// dereference the pointer to the entry once you know doc.GetExact did not
 	// return an error
-	content, err := doc.ReadToBytes(*entry)
+	content, err := (*entry).ContentBytes(doc)
 	if err != nil {
 		panic(err)
 	}

--- a/api-code-examples/go/doc-set.go
+++ b/api-code-examples/go/doc-set.go
@@ -3,35 +3,44 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Created author %s\n", author.ToString())
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	hash, err := doc.SetBytes(author, []byte("go"), []byte("says hello"))
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Inserted %s\n", hash.ToString())
 
-	content, err := doc.GetContentBytes(hash)
+	// returns a pointer to an entry
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+
+	// dereference the pointer to the entry once you know doc.GetExact did not
+	// return an error
+	content, err := doc.ReadToBytes(*entry)
 	if err != nil {
 		panic(err)
 	}

--- a/api-code-examples/go/doc-share.go
+++ b/api-code-examples/go/doc-share.go
@@ -3,33 +3,33 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	// TODO - sharing read-only tickets is not yet implemented. Coming soon!
-	// readTicket, err := doc.ShareRead()
+	// readTicket, err := doc.Share(iroh.ShareModeRead)
 	// if err != nil {
 	// 	panic(err)
 	// }
 	// fmt.Println(readTicket.ToString())
 
-	writeTicket, err := doc.ShareWrite()
+	writeTicket, err := doc.Share(iroh.ShareModeWrite)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Write-Access Ticket: %s", writeTicket.ToString())
+	fmt.Println("Write-Access Ticket:", writeTicket.ToString())
 	// Output:
 	// Created document 7hgonoxdjzlwtuicfyou24l5nhv3bmvzhyeq6v2er66ekrpvhotq
 	// Write-Access Ticket: sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg

--- a/api-code-examples/go/doc-share.go
+++ b/api-code-examples/go/doc-share.go
@@ -18,12 +18,11 @@ func main() {
 	}
 	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	// TODO - sharing read-only tickets is not yet implemented. Coming soon!
-	// readTicket, err := doc.Share(iroh.ShareModeRead)
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// fmt.Println(readTicket.ToString())
+	readTicket, err := doc.Share(iroh.ShareModeRead)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Read-Access Ticket:", readTicket.ToString())
 
 	writeTicket, err := doc.Share(iroh.ShareModeWrite)
 	if err != nil {
@@ -32,5 +31,6 @@ func main() {
 	fmt.Println("Write-Access Ticket:", writeTicket.ToString())
 	// Output:
 	// Created document 7hgonoxdjzlwtuicfyou24l5nhv3bmvzhyeq6v2er66ekrpvhotq
-	// Write-Access Ticket: sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg
+	// Read-Access Ticket: docahabhyiz37wlugkwb6cj424qparg6tz5ujmxpr6ac3rkbkvgjys3qajabdmaailylilvvj5ejqcaaa5gkz6pehua4vbu26bbjit2h7axb3lacaidaafakaacyrlqbooyzfgmivyaycuacioek4
+	// Write-Access Ticket: docaaqbt3lfrlih4yncth3rdwta4doendvv7e3fqtt27l6lf5tsfs6mqsibeaenqabbpbnbowvhurgaiaaduzlhz4q6qdsugtlyeffcpi74c4hnmaibamaaubiaalcfoafz3deuzrcxadakqajbyrlq
 }

--- a/api-code-examples/go/doc-watch.go
+++ b/api-code-examples/go/doc-watch.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type watch struct {
+	wg *sync.WaitGroup
+}
+
+func (w watch) Event(e *iroh.LiveEvent) *iroh.IrohError {
+	switch t := e.Type(); t {
+	case iroh.LiveEventTypeInsertLocal:
+		// returns the entry from the InsertLocal event
+		entry := e.AsInsertLocal()
+		fmt.Println("LiveEvent - InsertLocal: entry hash", entry.ContentHash().ToString())
+		w.wg.Done()
+	case iroh.LiveEventTypeInsertRemote:
+		insertRemoveEvent := e.AsInsertRemote()
+		fmt.Printf("LiveEvent - InsertRemote:\n\tfrom: %s\n\tentry hash:\n\tcontent_status: %v\n", insertRemoveEvent.From, insertRemoveEvent.Entry.ContentHash().ToString(), insertRemoveEvent.ContentStatus)
+		fmt.Println("Insert Remove events will be eventually followed by the ContentReady event")
+	case iroh.LiveEventTypeContentReady:
+		hash := e.AsContentReady()
+		fmt.Println("LiveEvent - ContentReady: hash", hash.ToString())
+	case iroh.LiveEventTypeNeighborUp:
+		nodeId := e.AsNeighborUp()
+		fmt.Println("LiveEvent - NeighborUp: node id", nodeId.ToString())
+	case iroh.LiveEventTypeNeighborDown:
+		nodeId := e.AsNeighborDown()
+		fmt.Println("LiveEvent - NeighborDown: node id", nodeId.ToString())
+	case iroh.LiveEventTypeSyncFinished:
+		syncEvent := e.AsSyncFinished()
+		fmt.Println("Live Event - SyncFinished: synced peer:", syncEvent.Peer.ToString())
+	default:
+		return &iroh.IrohError{}
+	}
+	return nil
+}
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	callback := watch{wg: &wg}
+
+	err = doc.Subscribe(callback)
+
+	key := []byte("watch-me")
+	_, err = doc.SetBytes(author, key, []byte("I'm going to trigger an InsertLocal event."))
+	if err != nil {
+		panic(err)
+	}
+
+	// wait for the watcher to get the insert local event
+	wg.Wait()
+	fmt.Println("Done!")
+}

--- a/api-code-examples/go/go.mod
+++ b/api-code-examples/go/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/n0-computer/iroh-ffi v0.0.7-0.20230927174552-77938699b905 // indirect
-	github.com/n0-computer/iroh-ffi/iroh-go v0.11.0-alpha // indirect
+	github.com/n0-computer/iroh-ffi/iroh-go v0.12.0 // indirect
 )
 
 replace github.com/n0-computer/iroh-ffi/iroh-go => ./extern/iroh-ffi/iroh-go

--- a/api-code-examples/go/go.mod
+++ b/api-code-examples/go/go.mod
@@ -2,4 +2,9 @@ module github.com/n0-computer/iroh.computer
 
 go 1.21.1
 
-require github.com/n0-computer/iroh-ffi v0.0.7-0.20230927174552-77938699b905 // indirect
+require (
+	github.com/n0-computer/iroh-ffi v0.0.7-0.20230927174552-77938699b905 // indirect
+	github.com/n0-computer/iroh-ffi/iroh-go v0.11.0-alpha // indirect
+)
+
+replace github.com/n0-computer/iroh-ffi/iroh-go => ./extern/iroh-ffi/iroh-go

--- a/api-code-examples/go/go.sum
+++ b/api-code-examples/go/go.sum
@@ -1,2 +1,4 @@
 github.com/n0-computer/iroh-ffi v0.0.7-0.20230927174552-77938699b905 h1:4djPw1iRtcsmA1qN7l7sd03U/pxkx/JFJ4yJO5RQofE=
 github.com/n0-computer/iroh-ffi v0.0.7-0.20230927174552-77938699b905/go.mod h1:puyEestvwIzSzADHLSeUe/vM2CyljV5hhKz6hcu7t94=
+github.com/n0-computer/iroh-ffi/iroh-go v0.11.0-alpha h1:1rERAwZjRcmprZn2owABT8vC8szhWQJ5NzzuOxZ7VDk=
+github.com/n0-computer/iroh-ffi/iroh-go v0.11.0-alpha/go.mod h1:4YFeQsObpqZ6OndeRGbs0xUIeukOdzPT4ptn8UZu8ug=

--- a/api-code-examples/python/author-list.py
+++ b/api-code-examples/python/author-list.py
@@ -1,13 +1,20 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
 authors = node.author_list()
+print("Authors:")
 for auth in authors:
-    print("Author: {}".format(auth.to_string()))
+    print("\t{}".format(auth.to_string()))
+
+# Output:
+# Started Iroh node: wbwpkauwmitrwwhmw534w3u6sxyhvbivuepcdze5jd3zeqpgxyfa
+# Created author: z2h3f3tozgz67g3ewvu7yxj5vtoddwoohzi2jgyrtgfl7tzocpda
+# Authors:
+#   z2h3f3tozgz67g3ewvu7yxj5vtoddwoohzi2jgyrtgfl7tzocpd

--- a/api-code-examples/python/author-new.py
+++ b/api-code-examples/python/author-new.py
@@ -1,9 +1,9 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))

--- a/api-code-examples/python/blob-add.py
+++ b/api-code-examples/python/blob-add.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import threading
+import time
+import shutil
+import datetime
+from iroh import IrohNode, SetTagOption, WrapOption, AddProgressType
+
+class AddCallback:
+    def progress(self, event):
+        t = event.type()
+        if t == AddProgressType.FOUND:
+            print("AddProgress - Found:")
+            found = event.as_found()
+            print(f"\tid: {found.id}, name: {found.name}, size: {found.size}")
+        elif t == AddProgressType.PROGRESS:
+            print("AddProgress - Progress:")
+            progress = event.as_progress()
+            print(f"\tid: {progress.id}, offset: {progress.offset}")
+        elif t == AddProgressType.DONE:
+            print("AddProgress - Done:")
+            done = event.as_done()
+            print(f"\tid: {done.id}, hash: {done.hash.to_string()}")
+        elif t == AddProgressType.ALL_DONE:
+            print("AddProgress - AllDone:")
+            all_done = event.as_all_done()
+            print(f"\thash: {all_done.hash.to_string()}, format: {all_done.format}, tag: {all_done.tag.to_string()}")
+        elif t == AddProgressType.ABORT:
+            print("AddProgress - Abort:")
+            abort = event.as_abort()
+            print(f"\terror: {abort.error}")
+        else:
+            print("Unknown AddProgress event:", event)
+
+# Create folder
+os.mkdir("tmp")
+
+try:
+    path = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    node = IrohNode("iroh_data_dir")
+
+    # When `in_place` is True, iroh will NOT copy over the files into its
+    # internal database. Only use this option when you know the file will never
+    # move or change.
+    in_place = False
+
+    # Iroh blobs can be "tagged" with human-readable names, this creates a tag
+    # automatically.
+    tag = SetTagOption.auto()
+
+    # When adding a single file, if you use `WrapOption.wrap()`, you will turn
+    # the single file into a collection with one entry.
+    wrap = WrapOption.no_wrap()
+
+    # You can use this callback to react to progress updates.
+    callback = AddCallback()
+
+    # Import the directory, creating one blob for each file, and one metadata
+    # blob that stores the file names for each blob.
+    # Also creates a 'collection' from the directory, grouping together the
+    # blobs.
+
+    node.blobs_add_from_path(path, in_place, tag, wrap, callback)
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# AddProgress - Found:
+# 	id: 1, name: $HOME/tmp/bar, size: 3
+# AddProgress - Found:
+# 	id: 0, name: $HOME/tmp/foo, size: 3
+# AddProgress - Found:
+# 	id: 2, name: $HOME/tmp/bat, size: 3
+# AddProgress - Progress:
+# 	id: 2, offset: 3
+# AddProgress - Progress:
+# 	id: 0, offset: 3
+# AddProgress - Done:
+# 	id: 0, hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e
+# AddProgress - Done:
+# 	id: 2, hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4
+# AddProgress - Progress:
+# 	id: 1, offset: 3
+# AddProgress - Done:
+# 	id: 1, hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu
+# AddProgress - AllDone:
+# 	hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim, format: BlobFormat.HASH_SEQ, tag: "auto-2023-12-09T22:25:45.296Z"

--- a/api-code-examples/python/blob-list-blobs.py
+++ b/api-code-examples/python/blob-list-blobs.py
@@ -1,0 +1,23 @@
+from iroh import IrohNode, SetTagOption
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Define content and tag
+content = b"hello world!"
+tag = SetTagOption.auto()
+
+# Add blob
+outcome = node.blobs_add_bytes(content, tag)
+print(f"Added blob {outcome.hash.to_string()} ({outcome.size} bytes)")
+
+print("blobs list:")
+
+# List blobs
+blobs = node.blobs_list()
+for hash in blobs:
+    print("\t", hash.to_string())
+
+# Output:
+# Added blob bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu (12 bytes)
+# blobs list:
+# 	 bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu

--- a/api-code-examples/python/blob-list-collections.py
+++ b/api-code-examples/python/blob-list-collections.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+
+from iroh import IrohNode, Tag, SetTagOption, WrapOption, AddProgressType
+
+class AddCallback:
+    hash = None
+
+    def progress(self, event):
+        if event.type() == AddProgressType.ALL_DONE:
+            all_done = event.as_all_done()
+            self.hash = all_done.hash
+
+# Create folder
+os.mkdir("tmp")
+try:
+    path = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    # Create an Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Options
+    in_place = False
+    tag = SetTagOption.named(Tag.from_string("my_collection"))
+    wrap = WrapOption.no_wrap()
+
+    # Callback setup
+    callback = AddCallback()
+
+    # Import the directory, creating one blob for each file, and one metadata
+    # blob that stores the file names for each blob
+    # also creates a 'collection' from the directory, grouping together the
+    # blobs
+    node.blobs_add_from_path(path, in_place, tag, wrap, callback)
+
+    hash = callback.hash
+
+    print("Added collection", hash.to_string())
+
+    print("collections list:")
+
+    coll_res = node.blobs_list_collections()
+    for res in coll_res:
+        print(f"\thash: {res.hash.to_string()} tag: {res.tag.to_string()}")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# Added collection bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim
+# collections list:
+# 	hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim tag: "my_collection"
+

--- a/api-code-examples/python/blob-list-incomplete-blobs.py
+++ b/api-code-examples/python/blob-list-incomplete-blobs.py
@@ -1,0 +1,15 @@
+from iroh import IrohNode
+
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Typically only happens if you have not finished syncing or interrupted
+# a download
+incompletes = node.blobs_list_incomplete()
+
+print("Incomplete blobs:")
+for res in incompletes:
+    print(f"\thash: {res.hash.to_string()} size: {res.size} expected size: {res.expected_size}")
+
+# Output:
+# Incomplete blobs:

--- a/api-code-examples/python/doc-delete.py
+++ b/api-code-examples/python/doc-delete.py
@@ -1,0 +1,50 @@
+from iroh import IrohNode, Query
+
+ # Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Real programs handle errors!
+author = node.author_create()
+print(f"Created author {author.to_string()}")
+
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
+
+# Get all the entries with default filtering and sorting
+query = Query.all(None)
+entries = doc.get_many(query)
+
+print("Keys:")
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = doc.read_to_bytes(entry)
+    print(f'{key.decode("utf-8")} : {content.decode("utf-8")} (hash: {hash.to_string()})')
+
+print(f"Removing entry for author {author.to_string()} and prefix {key.decode('utf-8')}.")
+# Removes all entries from that author and with the prefix "key"
+num_removed = doc.delete(author, key)
+print(f"Removed {num_removed} entry")
+
+entries = doc.get_many(query)
+
+print("Keys:")
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = doc.read_to_bytes(entry)
+    print(f'{key.decode("utf-8")} : {content.decode("utf-8")} (hash: {hash.to_string()})')
+
+# Output:
+# Created author ybkptbq4imifxaj544hl5etyszhecuepp66qlezov7sdzm3hqk4a
+# Created document ipqqeughovjrvcxl5sji3hlwycheqqgiajq5hgnf6vtqp6qigm6q
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Keys:
+# python : says hello (hash: bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte)
+# Removing entry for author ybkptbq4imifxaj544hl5etyszhecuepp66qlezov7sdzm3hqk4a and prefix python.
+# Removed 1 entry
+# Keys:

--- a/api-code-examples/python/doc-drop.py
+++ b/api-code-examples/python/doc-drop.py
@@ -1,0 +1,35 @@
+from iroh import IrohNode
+
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Create document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+print("List of docs and their capabilities (0-Read, 1-Write):")
+
+# Returns an array of `iroh.NamespaceAndCapability`s
+# NamespaceId is the Doc's Id
+# and the Capability is whether you have read or write access to the doc
+ns = node.doc_list()
+for entry in ns:
+    print(f"\t{entry.namespace.to_string()}\t{entry.capability}")
+
+# Drop document
+node.doc_drop(doc.id())
+print(f"Dropped document {doc.id().to_string()}")
+
+print("List of docs and their capabilities (0-Read, 1-Write):")
+ns = node.doc_list()
+# List no longer contains the dropped doc
+for entry in ns:
+    print(f"\t{entry.namespace.to_string()}\t{entry.capability}")
+
+# Output:
+# Created document zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq
+# List of docs and their capabilities:
+# 	zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq	CapabilityKind.WRITE
+# Dropped document zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq
+# List of docs and their capabilities:
+

--- a/api-code-examples/python/doc-export.py
+++ b/api-code-examples/python/doc-export.py
@@ -1,0 +1,72 @@
+import os
+import shutil
+from iroh import IrohNode, key_to_path, path_to_key
+
+# Create folder
+os.mkdir("tmp")
+
+# Create an export directory
+os.mkdir("export")
+
+try:
+    root = os.path.abspath(os.path.join("tmp"))
+    print(f"Created dir {root}")
+
+    # Create file
+    path = os.path.join("tmp", "hello_world")
+    with open(path, "w") as f:
+        f.write("Hello World!")
+    print(f"Created file \"hello_world\"")
+
+    # Create Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Create author and document
+    author = node.author_create()
+    print(f"Created author {author.to_string()}")
+
+    doc = node.doc_create()
+    print(f"Created document {doc.id().to_string()}")
+
+    prefix = "import-example"
+
+    # Import the file
+    path = os.path.abspath(os.path.join("tmp", "hello_world"))
+    key = path_to_key(path, prefix, root)
+    print(f"key: {key.decode('utf-8')}")
+    doc.import_file(author, key, path, False, None)
+
+    # Export the file
+    # Get the entry via an exact author and key
+    entry = doc.get_exact(author, key, False)
+
+    root = os.path.abspath(os.path.join("export"))
+    print(f"root: {root}")
+
+    # Create the export path from the key, prefix, and directory location
+    export_path = key_to_path(key, prefix, root)
+
+    # Export the entry
+    doc.export_file(entry, export_path, None)
+
+    # Open the exported file and print the contents
+    with open(export_path, "r") as f:
+        content = f.read()
+    print(f"file {export_path}: {content}")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+# cleanup export dir
+shutil.rmtree("export")
+
+# Output:
+# Created dir $HOME/tmp
+# Created file "hello_world"
+# Created author 2bgy4eozp5mcrhzqm6fylwpqsm2mddqogg4yphunegll2gxtmh4q
+# Created document mu65dqhxcchrfkfm6meyllitrpayljdra4qrqy54s4sgfwlgr2tq
+# key: import-examplehello_world
+# root: $HOME/export
+# file $HOME/export/hello_world: Hello World!

--- a/api-code-examples/python/doc-get.py
+++ b/api-code-examples/python/doc-get.py
@@ -1,19 +1,31 @@
-import iroh
+from iroh import IrohNode
+import os
 
-IROH_DATA_DIR = "./iroh-data"
+# Create a new Iroh node
+node = IrohNode("iroh_data_dir")
 
-node = iroh.IrohNode(IROH_DATA_DIR)
-print("Started Iroh node: {}".format(node.node_id()))
+# Create an author
+author = node.author_create()
+print(f"Created author {author.to_string()}")
 
-author = node.author_new()
-print("Created author: {}".format(author.to_string()))
+# Create a document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+# Set content in the document
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
 
-hash = doc.set_bytes(author, bytes("foo", "utf8"), bytes("bar", "utf8"))
-print("Inserted: {}".format(hash.to_string()))
+# Get an entry from the document
+entry = doc.get_exact(author, key, False)
 
-# FIXME: this doesn't work yet
-# content = doc.get_content_bytes(hash)
-# print("Got content: {}".format(content.decode("utf8")))
+# Read content from the entry
+content = entry.content_bytes(doc)
+print(f"Got content \"{content.decode('utf-8')}\"")
+
+# Output:
+# Created author huarctxgpvq2ucnifubjxvmac7c26evzudnynp5xrugkkm37ma7q
+# Created document zmwwfsnnoxgij4q5bknfij5tpwbm2askypip3al3bahinucx65oq
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Got content "says hello"

--- a/api-code-examples/python/doc-import.py
+++ b/api-code-examples/python/doc-import.py
@@ -1,0 +1,68 @@
+import os
+import shutil
+
+from iroh import IrohNode, Query, path_to_key 
+
+# Create folder
+os.mkdir("tmp")
+
+try:
+    root = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    # Create an Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Create author and document
+    author = node.author_create()
+    print(f"Created author {author.to_string()}")
+
+    doc = node.doc_create()
+    print(f"Created document {doc.id().to_string()}")
+
+    prefix = "import-example"
+    # Import the files
+    for file_name in file_names:
+        path = os.path.abspath(os.path.join("tmp", file_name))
+        # create a key from the path, use the `iroh.PathToKey` function to ensure
+		# that we strip the root correctly, and add any prefix we want to add for
+		# organizational purposes
+        key = path_to_key(path, prefix, root)
+        doc.import_file(author, key, path, False, None)
+
+    # Get all the entries with default filtering and sorting
+    query = Query.all(None)
+    entries = doc.get_many(query)
+
+    print("One entry for each file:")
+    for entry in entries:
+        key = entry.key()
+        hash = entry.content_hash()
+        content = entry.content_bytes(doc)
+        print(f"{key.decode('utf-8')}: {content.decode('utf-8')} (hash: {hash.to_string()})")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# Created author kpksn2yl2c3nlppjtnpxa2h2utmu2fdnutuwptybenr3gxdlrkiq
+# Created document af7klzttoegn6kvr7p6j7tgw6tz2w54n5bfzqvpcfmy2mrkk3pgq
+# One entry for each file:
+# import-examplebar: bar (hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu)
+# import-examplebat: bat (hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4)
+# import-examplefoo: foo (hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e)

--- a/api-code-examples/python/doc-join.py
+++ b/api-code-examples/python/doc-join.py
@@ -1,14 +1,14 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 # you'll need to get a ticket from somewhere, see the `doc share` command documentation
 # for details. This ticket will fail to join, but is a valid ticket.
-TICKET_STRING = "sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg"
+TICKET_STRING = "docaaa7qg6afc6zupqzfxmu5uuueaoei5zlye7a4ahhrfhvzjfrfewozgybl5kkl6u6fqcnjxvdkoihq3nbsqczxeulfsqvatb2qh3bwheoyahacitior2ha4z2f4xxk43fgewtcltemvzhaltjojxwqltomv2ho33snmxc6biajjeteswek4ambkabzpcfoajganyabbz2zplaaaaaaaaaagrjyvlqcjqdoaaioowl2ygi2likyov62rofk4asma3qacdtvs6whqsdbizopsefrrkx"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
 doc_ticket = iroh.DocTicket.from_string(TICKET_STRING)
 doc = node.doc_join(doc_ticket)
-print("Joined doc: {}".format(doc.id()))
+print("Joined doc: {}".format(doc.id().to_string()))

--- a/api-code-examples/python/doc-keys.py
+++ b/api-code-examples/python/doc-keys.py
@@ -1,21 +1,34 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 for i, key in enumerate(['a', 'b', 'c']):
     doc.set_bytes(author, bytes(key, "utf8"), bytes(str(i), "utf8"))
 
-keys = doc.keys()
+# get all the entries with default filtering and sorting
+query = iroh.Query.all(None)
+entries = doc.get_many(query)
 print("Keys:")
-for key in keys:
-    content = doc.get_content_bytes(key)
-    print("{} : {} (hash: {})".format(key.key(), content.decode("utf8"), key.hash().to_string()))
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = entry.content_bytes(doc)
+    print("{} : {} (hash: {})".format(key, content.decode("utf8"), hash.to_string()))
+
+# Output:
+# Started Iroh node: f5seybgjqa4yrnqbhcibxyckykzile76ygfnpqhslpjzlztssrlq
+# Created author: sf6zsxtzdsbrofaghjhso3czyyfciipxxldplhfkbc34abqmtbha
+# Created doc: sqsx7kn3nfvjhziwhcjnoa47fpisbqtox4363nf4uxzhxwehxnba
+# Keys:
+# b'a' : 0 (hash: bafkr4icnazyvhldstjfh5arazf4tl752m5ehqygvqkmm52zdqzbwtbt5t4)
+# b'b' : 1 (hash: bafkr4igwhpm2qjvpsha75i3rszngjyi64ihrhzdll5jmlgibcntalm5eq4)
+# b'c' : 2 (hash: bafkr4iebh2nxfekb47zyll5aulin6ptmg6e6ij774sxo6vtkkzn4r4x6hu)

--- a/api-code-examples/python/doc-list.py
+++ b/api-code-examples/python/doc-list.py
@@ -1,20 +1,30 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
 # create a document
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 # create a second document
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 # list all your documents
 docs = node.doc_list();
 print("List all {} docs:".format(len(docs)))
-for doc in docs:
-    print("\t{}".format(doc.to_string()))
+# doc ids are also called "namespace ids"
+for namespace_and_capability in docs:
+    print("\t{}".format(namespace_and_capability.namespace.to_string()))
+
+# Output:
+# Started Iroh node: jplmb4cgk2pxw3dwjehk7oes7ddphftlh3vdiib4e5bwhq2nnokq
+# Created doc: mr42ra4f6n63kkd6kmqghgonsanqqtpv5cvkgcu7bpg2zaauimrq
+# Created doc: n4w6eip5cgxlv33dl3nln544km76t4gt2etpml6kc6qpo6sqmdua
+# List all 2 docs:
+# 	mr42ra4f6n63kkd6kmqghgonsanqqtpv5cvkgcu7bpg2zaauimrq
+# 	n4w6eip5cgxlv33dl3nln544km76t4gt2etpml6kc6qpo6sqmdua
+

--- a/api-code-examples/python/doc-new.py
+++ b/api-code-examples/python/doc-new.py
@@ -1,12 +1,12 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))

--- a/api-code-examples/python/doc-set.py
+++ b/api-code-examples/python/doc-set.py
@@ -1,19 +1,31 @@
-import iroh
+from iroh import IrohNode
+import os
 
-IROH_DATA_DIR = "./iroh-data"
+# Create a new Iroh node
+node = IrohNode("iroh_data_dir")
 
-node = iroh.IrohNode(IROH_DATA_DIR)
-print("Started Iroh node: {}".format(node.node_id()))
+# Create an author
+author = node.author_create()
+print(f"Created author {author.to_string()}")
 
-author = node.author_new()
-print("Created author: {}".format(author.to_string()))
+# Create a document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+# Set content in the document
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
 
-hash = doc.set_bytes(author, bytes("foo", "utf8"), bytes("bar", "utf8"))
-print("Inserted: {}".format(hash.to_string()))
+# Get an entry from the document
+entry = doc.get_exact(author, key, False)
 
-# FIXME: this doesn't work yet
-# content = doc.get_content_bytes(hash)
-# print("Got content: {}".format(content.decode("utf8")))
+# Read content from the entry
+content = entry.content_bytes(doc)
+print(f"Got content \"{content.decode('utf-8')}\"")
+
+# Output:
+# Created author huarctxgpvq2ucnifubjxvmac7c26evzudnynp5xrugkkm37ma7q
+# Created document zmwwfsnnoxgij4q5bknfij5tpwbm2askypip3al3bahinucx65oq
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Got content "says hello"

--- a/api-code-examples/python/doc-share.py
+++ b/api-code-examples/python/doc-share.py
@@ -1,15 +1,25 @@
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
-ticket = doc.share_write()
+ticket = doc.share(iroh.ShareMode.READ)
+print("Read-Access Ticket: {}".format(ticket.to_string()))
+
+ticket = doc.share(iroh.ShareMode.WRITE)
 print("Write-Access Ticket: {}".format(ticket.to_string()))
+
+# Output:
+# Started Iroh node: rwgutd2wazt756h5awh6x576jejizai6w2l6ae5gxsv7tpswmopq
+# Created author: ivn4qsyq3utro5px6k5k5hnbpp6eqh6l5u667hpkgbsglpadfowq
+# Created doc: ijgvnoxfgkkgze3cyb7rwjywfqvfzy2pzilo2tn5wf64fgm7nxkq
+# Read-Access Ticket: docafbe2vv24uzji3etmlah6gzhcywcuxhdj7fbn3knxwyx3quzt5w5kajarwgutd2wazt756h5awh6x576jejizai6w2l6ae5gxsv7tpswmopqcaifabfesmskyrlqbqfiahf4ivybeybxaaehhlf5maaaaaaaaaa2fhcvoajganyabbz2zplazdjnblb2x3kfyvlqcjqdoaaioowl2zctm6q34dlgzp6fk4
+# Write-Access Ticket: docaaqo2dtt7udula5vvevfwjenux3tk3l3lfpefugeu6r6v55pwusvc5qbecgy2smpkydgp7xy7ucy727x7zerfdebd23jpyatu26kx6n6kzrz6aibauaeusjsjlcfoagavaa4xrcxaetag4aaq45mxvqaaaaaaaaadiu4kvybeybxaaehhlf5mdenfufmhk7nixcvoajganyabbz2zpleknt2dpqnm3f7yvlq

--- a/api-code-examples/python/doc-watch.py
+++ b/api-code-examples/python/doc-watch.py
@@ -1,0 +1,61 @@
+import queue
+from iroh import IrohNode, LiveEventType
+
+class Watch:
+    def __init__(self, queue):
+        self.queue = queue
+
+    def event(self, e):
+        t = e.type()
+        if t == LiveEventType.INSERT_LOCAL:
+            entry = e.as_insert_local()
+            print(f"LiveEvent - InsertLocal: entry hash {entry.content_hash().to_string()}")
+            self.queue.put(True)
+        elif t == LiveEventType.INSERT_REMOTE:
+            insert_remove_event = e.as_insert_remote()
+            print(f"LiveEvent - InsertRemote:\n\tfrom: {insert_remove_event.from_}\n\tentry hash:\n\t{insert_remove_event.entry.content_hash().to_string()}\n\tcontent_status: {insert_remove_event.content_status}")
+            print("Insert Remove events will be eventually followed by the ContentReady event")
+        elif t == LiveEventType.CONTENT_READY:
+            hash_val = e.as_content_ready()
+            print(f"LiveEvent - ContentReady: hash {hash_val.to_string()}")
+        elif t == LiveEventType.NEIGHBOR_UP:
+            node_id = e.as_neighbor_up()
+            print(f"LiveEvent - NeighborUp: node id {node_id.to_string()}")
+        elif t == LiveEventType.NEIGHBOR_DOWN:
+            node_id = e.as_neighbor_down()
+            print(f"LiveEvent - NeighborDown: node id {node_id.to_string()}")
+        elif t == LiveEventType.SYNC_FINISHED:
+            sync_event = e.as_sync_finished()
+            print(f"Live Event - SyncFinished: synced peer: {sync_event.peer.to_string()}")
+        else:
+            raise Exception("unknown LiveEventType")
+
+# Create Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Create author and document
+author = node.author_create()
+print(f"Created author {author.to_string()}")
+
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+# Create a queue for synchronization
+event_queue = queue.Queue()
+
+callback = Watch(event_queue)
+doc.subscribe(callback)
+
+key = b"watch-me"
+doc.set_bytes(author, key, b"I'm going to trigger an InsertLocal event.")
+
+# Wait for the watcher to get the insert local event
+event_queue.get()
+
+print("Done!")
+
+# Output:
+# Created author 4zxg622q75rko5t4nqgxpe7mznavaajquwcjwrknoia6s2fu2sja
+# Created document 3h6ea3d6ucs3iicwn2hzovpwhh3lpchs7b6nt5byoci3aqt6amfa
+# LiveEvent - InsertLocal: entry hash bafkr4ic24i3eenzjflowjva7e2tyw24yafro5kvve6p6ziwics5kc2id5e
+# Done!

--- a/api-code-examples/run_files.sh
+++ b/api-code-examples/run_files.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Get the absolute path to the script's directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Name of the directory we use for the iroh node
+IROH_DATA_DIR="iroh_data_dir"
+
+# List of file names without extensions
+files=(
+    "author-list"
+    "author-new"
+    "blob-add"
+    "blob-list-blobs"
+    "blob-list-collections"
+    "blob-list-incomplete-blobs"
+    # "doc-delete"
+    "doc-drop"
+    "doc-export"
+    "doc-get"
+    "doc-import"
+    "doc-join"
+    "doc-keys"
+    "doc-list"
+    "doc-new"
+    "doc-set"
+    "doc-share"
+    "doc-watch"
+)
+
+# Clean up on exit
+cleanup() {
+  echo "Cleaning up..."
+  rm -rf "$SCRIPT_DIR/go/$IROH_DATA_DIR"
+  rm -rf "$SCRIPT_DIR/python/$IROH_DATA_DIR"
+}
+
+# Trap the EXIT signal to ensure cleanup
+trap cleanup EXIT
+
+# Iterate over each file
+for file in "${files[@]}"; do
+    # Change directory to "go" and run the Go file
+    echo "Running $file.go..."
+    (cd "$SCRIPT_DIR/go" && go run "$file.go")
+    status=$?
+
+    if [ $status -ne 0 ]; then
+        echo "Error running $file.go. Exiting..."
+        exit $status
+    fi
+
+    echo "-----------------------"
+
+    # Change directory to "python" and run the Python file
+    echo "Running $file.py..."
+    (cd "$SCRIPT_DIR/python" && python3 "$file.py")
+    status=$?
+
+    if [ $status -ne 0 ]; then
+        echo "Error running $file.py. Exiting..."
+        exit $status
+    fi
+
+    echo "-----------------------"
+done
+
+rm -r "$SCRIPT_DIR/python/iroh_data_dir"
+rm -r "$SCRIPT_DIR/go/iroh_data_dir"
+
+echo "All Go and Python files executed successfully!"

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,10 @@ Finally, open [http://localhost:3000](http://localhost:3000) in your browser to 
 ## Editing docs content
 Our docs are generated. Use the following steps to make adjustments to the content and update the website to match:
 
-- make your edits to the documentation in the `command-code-examples/commands.mjs` file
+- make your edits to the documentation in the `api-code-examples/api.mjs` file
 - cd into the `scripts` folder
 - run `npm install` if you have not run it in this folder previously
-- run `node generate-commands-pages.js` to generate the doc files for the website
+- run `node generate-api-pages.js` to generate the doc files for the website
 
 ### Style / grammar guide
 Follow the style that has already been layed out. But as a general rule of thumb, follow normal English punctuation, but favor brevity over proper grammar. In other words, use capital letters at the start of sentences, and end them with a period, but sentences can be fragments if that gets the point across quicker.

--- a/src/app/docs/api/author-list/page.mdx
+++ b/src/app/docs/api/author-list/page.mdx
@@ -30,17 +30,24 @@ wkl4cgrykxvcvr6pjnbvymrzm7h4je7d4ztszp35xfnk2rnflcxq
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
 authors = node.author_list()
+print("Authors:")
 for auth in authors:
-    print("Author: {}".format(auth.to_string()))
+    print("\t{}".format(auth.to_string()))
+
+# Output:
+# Started Iroh node: wbwpkauwmitrwwhmw534w3u6sxyhvbivuepcdze5jd3zeqpgxyfa
+# Created author: z2h3f3tozgz67g3ewvu7yxj5vtoddwoohzi2jgyrtgfl7tzocpda
+# Authors:
+#   z2h3f3tozgz67g3ewvu7yxj5vtoddwoohzi2jgyrtgfl7tzocpd
 
 ```
 
@@ -50,26 +57,29 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	if _, err := node.AuthorNew(); err != nil {
+	author, err := node.AuthorCreate()
+	if err != nil {
 		panic(err)
 	}
+	fmt.Println("Created author:", author.ToString())
 
 	authors, err := node.AuthorList()
 	if err != nil {
 		panic(err)
 	}
 
+	fmt.Println("Authors:")
 	for _, author := range authors {
-		fmt.Println(author.ToString())
+		fmt.Println("\t", author.ToString())
 	}
 }
 

--- a/src/app/docs/api/author-new/page.mdx
+++ b/src/app/docs/api/author-new/page.mdx
@@ -40,12 +40,12 @@ author:2rkuvpk4…
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
 ```
@@ -56,16 +56,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}

--- a/src/app/docs/api/blob-add/page.mdx
+++ b/src/app/docs/api/blob-add/page.mdx
@@ -38,5 +38,247 @@ Total: 328 B
 Collection: bafkr4ie3xsx3vdsbflainnk6p4xs4h2hq3hdmuasuoflkgybvnsbljb3ke
 ```
 
+```python {{ title: 'python' }}
+import os
+import sys
+import threading
+import time
+import shutil
+import datetime
+from iroh import IrohNode, SetTagOption, WrapOption, AddProgressType
+
+class AddCallback:
+    def progress(self, event):
+        t = event.type()
+        if t == AddProgressType.FOUND:
+            print("AddProgress - Found:")
+            found = event.as_found()
+            print(f"\tid: {found.id}, name: {found.name}, size: {found.size}")
+        elif t == AddProgressType.PROGRESS:
+            print("AddProgress - Progress:")
+            progress = event.as_progress()
+            print(f"\tid: {progress.id}, offset: {progress.offset}")
+        elif t == AddProgressType.DONE:
+            print("AddProgress - Done:")
+            done = event.as_done()
+            print(f"\tid: {done.id}, hash: {done.hash.to_string()}")
+        elif t == AddProgressType.ALL_DONE:
+            print("AddProgress - AllDone:")
+            all_done = event.as_all_done()
+            print(f"\thash: {all_done.hash.to_string()}, format: {all_done.format}, tag: {all_done.tag.to_string()}")
+        elif t == AddProgressType.ABORT:
+            print("AddProgress - Abort:")
+            abort = event.as_abort()
+            print(f"\terror: {abort.error}")
+        else:
+            print("Unknown AddProgress event:", event)
+
+# Create folder
+os.mkdir("tmp")
+
+try:
+    path = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    node = IrohNode("iroh_data_dir")
+
+    # When `in_place` is True, iroh will NOT copy over the files into its
+    # internal database. Only use this option when you know the file will never
+    # move or change.
+    in_place = False
+
+    # Iroh blobs can be "tagged" with human-readable names, this creates a tag
+    # automatically.
+    tag = SetTagOption.auto()
+
+    # When adding a single file, if you use `WrapOption.wrap()`, you will turn
+    # the single file into a collection with one entry.
+    wrap = WrapOption.no_wrap()
+
+    # You can use this callback to react to progress updates.
+    callback = AddCallback()
+
+    # Import the directory, creating one blob for each file, and one metadata
+    # blob that stores the file names for each blob.
+    # Also creates a 'collection' from the directory, grouping together the
+    # blobs.
+
+    node.blobs_add_from_path(path, in_place, tag, wrap, callback)
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# AddProgress - Found:
+# 	id: 1, name: $HOME/tmp/bar, size: 3
+# AddProgress - Found:
+# 	id: 0, name: $HOME/tmp/foo, size: 3
+# AddProgress - Found:
+# 	id: 2, name: $HOME/tmp/bat, size: 3
+# AddProgress - Progress:
+# 	id: 2, offset: 3
+# AddProgress - Progress:
+# 	id: 0, offset: 3
+# AddProgress - Done:
+# 	id: 0, hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e
+# AddProgress - Done:
+# 	id: 2, hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4
+# AddProgress - Progress:
+# 	id: 1, offset: 3
+# AddProgress - Done:
+# 	id: 1, hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu
+# AddProgress - AllDone:
+# 	hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim, format: BlobFormat.HASH_SEQ, tag: "auto-2023-12-09T22:25:45.296Z"
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type addCallback struct {
+}
+
+func (a addCallback) Progress(event *iroh.AddProgress) *iroh.IrohError {
+	switch t := event.Type(); t {
+	case iroh.AddProgressTypeFound:
+		fmt.Println("AddProgress - Found:")
+		found := event.AsFound()
+		fmt.Printf("\tid: %d, name: %s, size: %d\n", found.Id, found.Name, found.Size)
+	case iroh.AddProgressTypeProgress:
+		fmt.Println("AddProgress - Progress:")
+		progress := event.AsProgress()
+		fmt.Printf("\tid: %d, offset: %d\n", progress.Id, progress.Offset)
+	case iroh.AddProgressTypeDone:
+		fmt.Println("AddProgress - Done:")
+		done := event.AsDone()
+		fmt.Printf("\tid: %d, hash: %s\n", done.Id, done.Hash.ToString())
+	case iroh.AddProgressTypeAllDone:
+		fmt.Println("AddProgress - AllDone:")
+		allDone := event.AsAllDone()
+		fmt.Printf("\thash: %s, format: %v, tag: %s\n", allDone.Hash.ToString(), allDone.Format, allDone.Tag.ToString())
+	case iroh.AddProgressTypeAbort:
+		fmt.Println("AddProgress - Abort:")
+		abort := event.AsAbort()
+		fmt.Printf("\terror: %s", abort.Error)
+	default:
+		fmt.Println("Unknown AddProgress event: %v", event)
+		return &iroh.IrohError{}
+	}
+	return nil
+}
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	path, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// when `inPlace` is true, iroh will NOT copy over the files into its
+	// internal database. Only use this option when you know the file will never
+	// move or change
+	inPlace := false
+	// iroh blobs can be "tagged" with human readable names, this creates a tag
+	// automatically
+	tag := iroh.SetTagOptionAuto()
+	// when adding a single file, if you use `iroh.WrapOptionWrap`, you will turn
+	// the single file into a collection with one entry
+	wrap := iroh.WrapOptionNoWrap()
+	// you can use this callback to react to progress updates
+	callback := addCallback{}
+
+	// import the directory, creating one blob for each file, and one metadata
+	// blob that stores the file names for each blob
+	// also creates a 'collection' from the directory, grouping together the
+	// blobs
+
+	err = node.BlobsAddFromPath(path, inPlace, tag, wrap, callback)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"
+	// Created file "tmp/bar"
+	// Created file "tmp/bat"
+	// AddProgress - Found:
+	//    id: 2, name: $HOME/tmp/bar, size: 3
+	// AddProgress - Found:
+	//		id: 0, name: $HOME/tmp/foo, size: 3
+	// AddProgress - Found:
+	//		id: 1, name: $HOME/tmp/bat, size: 3
+	// AddProgress - Progress:
+	//		id: 1, offset: 3
+	// AddProgress - Done:
+	//		id: 1, hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4
+	// AddProgress - Progress:
+	//		id: 2, offset: 3
+	// AddProgress - Progress:
+	//		id: 0, offset: 3
+	// AddProgress - Done:
+	//		id: 2, hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu
+	// AddProgress - Done:
+	//		id: 0, hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e
+	// AddProgress - AllDone:
+	//		hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim, format: 2, tag: "auto-2023-12-09T17:37:42.432Z"
+	// Removed dir 'tmp'
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/blob-list-blobs/page.mdx
+++ b/src/app/docs/api/blob-list-blobs/page.mdx
@@ -32,5 +32,79 @@ List the available blobs on the running provider. {{ className: 'lead' }}
  bafkr4ih5e75yrvu63folnkhvppj3pnx3he2oudmr35x2xc2puodrr2kryy (47 B)
 ```
 
+```python {{ title: 'python' }}
+from iroh import IrohNode, SetTagOption
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Define content and tag
+content = b"hello world!"
+tag = SetTagOption.auto()
+
+# Add blob
+outcome = node.blobs_add_bytes(content, tag)
+print(f"Added blob {outcome.hash.to_string()} ({outcome.size} bytes)")
+
+print("blobs list:")
+
+# List blobs
+blobs = node.blobs_list()
+for hash in blobs:
+    print("\t", hash.to_string())
+
+# Output:
+# Added blob bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu (12 bytes)
+# blobs list:
+# 	 bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	b := []byte("hello world!")
+	tag := iroh.SetTagOptionAuto()
+
+	// add blob
+	outcome, err := node.BlobsAddBytes(b, tag)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Added blob %s (%d bytes)\n", outcome.Hash.ToString(), outcome.Size)
+
+	fmt.Println("blobs list:")
+
+	blobs, err := node.BlobsList()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, hash := range blobs {
+		fmt.Println("\t", hash.ToString())
+	}
+
+	// Output:
+	// Added blob bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu (12 bytes)
+	// blobs list:
+	//  bafkr4ib2uyoebh6xof6j3hddsibk6l5oi4ga55tjxz52fsxkk544wu2otu
+	//
+	//  (may contain additional hashes if you have previously added content to your node)
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/blob-list-collections/page.mdx
+++ b/src/app/docs/api/blob-list-collections/page.mdx
@@ -25,5 +25,193 @@ List the available collections on the running provider. {{ className: 'lead' }}
 > 
 ```
 
+```python {{ title: 'python' }}
+import os
+import shutil
+
+from iroh import IrohNode, Tag, SetTagOption, WrapOption, AddProgressType
+
+class AddCallback:
+    hash = None
+
+    def progress(self, event):
+        if event.type() == AddProgressType.ALL_DONE:
+            all_done = event.as_all_done()
+            self.hash = all_done.hash
+
+# Create folder
+os.mkdir("tmp")
+try:
+    path = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    # Create an Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Options
+    in_place = False
+    tag = SetTagOption.named(Tag.from_string("my_collection"))
+    wrap = WrapOption.no_wrap()
+
+    # Callback setup
+    callback = AddCallback()
+
+    # Import the directory, creating one blob for each file, and one metadata
+    # blob that stores the file names for each blob
+    # also creates a 'collection' from the directory, grouping together the
+    # blobs
+    node.blobs_add_from_path(path, in_place, tag, wrap, callback)
+
+    hash = callback.hash
+
+    print("Added collection", hash.to_string())
+
+    print("collections list:")
+
+    coll_res = node.blobs_list_collections()
+    for res in coll_res:
+        print(f"\thash: {res.hash.to_string()} tag: {res.tag.to_string()}")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# Added collection bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim
+# collections list:
+# 	hash: bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim tag: "my_collection"
+
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type addCallback struct {
+	hashCh chan iroh.Hash
+}
+
+func (a addCallback) Progress(event *iroh.AddProgress) *iroh.IrohError {
+	if event.Type() == iroh.AddProgressTypeAllDone {
+		allDone := event.AsAllDone()
+		a.hashCh <- *allDone.Hash
+	}
+	return nil
+}
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	path, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// when `inPlace` is true, iroh will NOT copy over the files into its
+	// internal database. Only use this option when you know the file will never
+	// move or change
+	inPlace := false
+	// iroh blobs can be "tagged" with human readable names, this creates a tag
+	// automatically
+	tag := iroh.SetTagOptionNamed(iroh.TagFromString("my_collection"))
+	// when adding a single file, if you use `iroh.WrapOptionWrap`, you will turn
+	// the single file into a collection with one entry
+	wrap := iroh.WrapOptionNoWrap()
+	// you can use this callback to react to progress updates
+	hashCh := make(chan iroh.Hash, 1)
+	callback := addCallback{hashCh}
+
+	// import the directory, creating one blob for each file, and one metadata
+	// blob that stores the file names for each blob
+	// also creates a 'collection' from the directory, grouping together the
+	// blobs
+
+	err = node.BlobsAddFromPath(path, inPlace, tag, wrap, callback)
+	if err != nil {
+		panic(err)
+	}
+
+	hash := <-hashCh
+
+	fmt.Println("Added collection", hash.ToString())
+
+	fmt.Println("collections list:")
+
+	collRes, err := node.BlobsListCollections()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, res := range collRes {
+		fmt.Printf("\thash: %s tag: %s\n", res.Hash.ToString(), res.Tag.ToString())
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"
+	// Created file "tmp/bar"
+	// Created file "tmp/bat"
+	// AllDone
+	// Added collection bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim
+	// collections list:
+	// 	hash:bafkr4iaotzhxuiak7eusnngngnwsqdu4crf4lmdxzkbhuebunevecjzkim tag:"my_collection"
+	// Removed dir 'tmp'
+	//
+	// (may contain additional collections if you have previously added content to your node)
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/blob-list-incomplete-blobs/page.mdx
+++ b/src/app/docs/api/blob-list-incomplete-blobs/page.mdx
@@ -25,5 +25,57 @@ List the blobs on the running provider that are not full files. {{ className: 'l
 > 
 ```
 
+```python {{ title: 'python' }}
+from iroh import IrohNode
+
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Typically only happens if you have not finished syncing or interrupted
+# a download
+incompletes = node.blobs_list_incomplete()
+
+print("Incomplete blobs:")
+for res in incompletes:
+    print(f"\thash: {res.hash.to_string()} size: {res.size} expected size: {res.expected_size}")
+
+# Output:
+# Incomplete blobs:
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	// typically only happens if you have not finished syncing or interrupted
+	// a download
+	incompletes, err := node.BlobsListIncomplete()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Incomplete blobs:")
+	for _, res := range incompletes {
+		fmt.Printf("\thash: %s size: %s expected size: %d\n", res.Hash.ToString(), res.Size, res.ExpectedSize)
+	}
+
+	// Output:
+	// Incomplete blobs:
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/doc-delete/page.mdx
+++ b/src/app/docs/api/doc-delete/page.mdx
@@ -1,0 +1,193 @@
+{/* THIS FILE IS GENERATED FROM A TEMPLATE. See scripts/generate-api-pages.js for more */}
+import Breadcrumbs from '@/components/Breadcrumbs'
+export const metadata = {
+    title: "doc delete",
+    description: "Delete all document entries below a key prefix."
+}
+
+<div className='not-prose mb-5'>
+    <Breadcrumbs pages={[
+        { name: 'API', href: '/docs/api', current: false },
+        { name: 'doc delete', href: '/docs/api/doc-delete', current: true },
+    ]} />
+</div>
+
+# doc delete
+
+Delete all document entries below a key prefix. {{ className: 'lead' }}
+
+
+### Arguments
+
+| name | necessity | description |
+| ---- | --------- | ----------- |
+| prefix  | required | Prefix to delete. All entries whose key starts with or is equal to the prefix will be deleted |
+
+
+
+## Examples
+
+<CodeGroup title="doc delete">
+```text {{ title: 'console' }}
+> doc new --switch
+2aoukeibc2vdy5n2jlihnyv3e26cmketqbropptqfef3v7poe5eq
+Active doc is now 2aoukeibc2vdy5n2
+      
+author:luo73rdznvupzrjb doc:2aoukeibc2vdy5n2 
+> doc set key value
+bafkr4iagirfesfxon7wneztow6ila3w5mm53jnmcq4sek6nnnxxv7wk6bm
+
+author:luo73rdznvupzrjb doc:2aoukeibc2vdy5n2 
+> doc del key
+Deleting all entries whose key starts with key. Continue? yes
+Deleted 1 entries.
+Inserted an empty entry for author luo73rdznvupzrjb with key key
+```
+
+```python {{ title: 'python' }}
+from iroh import IrohNode, Query
+
+ # Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Real programs handle errors!
+author = node.author_create()
+print(f"Created author {author.to_string()}")
+
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
+
+# Get all the entries with default filtering and sorting
+query = Query.all(None)
+entries = doc.get_many(query)
+
+print("Keys:")
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = doc.read_to_bytes(entry)
+    print(f'{key.decode("utf-8")} : {content.decode("utf-8")} (hash: {hash.to_string()})')
+
+print(f"Removing entry for author {author.to_string()} and prefix {key.decode('utf-8')}.")
+# Removes all entries from that author and with the prefix "key"
+num_removed = doc.delete(author, key)
+print(f"Removed {num_removed} entry")
+
+entries = doc.get_many(query)
+
+print("Keys:")
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = doc.read_to_bytes(entry)
+    print(f'{key.decode("utf-8")} : {content.decode("utf-8")} (hash: {hash.to_string()})')
+
+# Output:
+# Created author ybkptbq4imifxaj544hl5etyszhecuepp66qlezov7sdzm3hqk4a
+# Created document ipqqeughovjrvcxl5sji3hlwycheqqgiajq5hgnf6vtqp6qigm6q
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Keys:
+# python : says hello (hash: bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte)
+# Removing entry for author ybkptbq4imifxaj544hl5etyszhecuepp66qlezov7sdzm3hqk4a and prefix python.
+# Removed 1 entry
+# Keys:
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		// real programs handle errors!
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Inserted %s\n", hash.ToString())
+
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Keys:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := doc.ReadToBytes(entry)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	fmt.Printf("Removing entry for author %s and prefix %s.\n", author.ToString(), string(key))
+	// removes all entries from that author and with the prefix "key"
+	num_removed, err := doc.Delete(author, key)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Removed %d entry\n", num_removed)
+
+	// get all the entries with default filtering and sorting
+	entries, err = doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Keys:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := doc.ReadToBytes(entry)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	// Output:
+	// Created author x2xi6sosy2yafpj3xx6zzocvfxzzdrwlkhaqew5v4pcccg2rtesa
+	// Created document bq3ioxh7licvicknhuxl2in24qagzlewoaotgvm3xbr6nxwrv7ea
+	// Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+	// Keys:
+	// "go" : "says hello" (hash: bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte)
+	// Removing entry for author x2xi6sosy2yafpj3xx6zzocvfxzzdrwlkhaqew5v4pcccg2rtesa and prefix go.
+	// Removed 1 entry
+	// Keys:
+}
+
+```
+
+
+</CodeGroup>

--- a/src/app/docs/api/doc-drop/page.mdx
+++ b/src/app/docs/api/doc-drop/page.mdx
@@ -44,5 +44,104 @@ Delete document 2aoukeibc2vdy5n2? yes
 Doc 2aoukeibc2vdy5n2 has been deleted.
 ```
 
+```python {{ title: 'python' }}
+from iroh import IrohNode
+
+# Create an Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Create document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+print("List of docs and their capabilities (0-Read, 1-Write):")
+
+# Returns an array of `iroh.NamespaceAndCapability`s
+# NamespaceId is the Doc's Id
+# and the Capability is whether you have read or write access to the doc
+ns = node.doc_list()
+for entry in ns:
+    print(f"\t{entry.namespace.to_string()}\t{entry.capability}")
+
+# Drop document
+node.doc_drop(doc.id())
+print(f"Dropped document {doc.id().to_string()}")
+
+print("List of docs and their capabilities (0-Read, 1-Write):")
+ns = node.doc_list()
+# List no longer contains the dropped doc
+for entry in ns:
+    print(f"\t{entry.namespace.to_string()}\t{entry.capability}")
+
+# Output:
+# Created document zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq
+# List of docs and their capabilities:
+# 	zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq	CapabilityKind.WRITE
+# Dropped document zdv4ciupnlhxzvydn3f227k7tkq3pdljie7de6gtsesghmuu6tyq
+# List of docs and their capabilities:
+
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	fmt.Println("List of docs and their capabilities (0-Read, 1-Write):")
+
+	// returns an array of `iroh.NamespaceAndCapability`s
+	// NamespaceId is the Doc's Id
+	// and the Capability is whether you have read or write access to the doc
+	ns, err := node.DocList()
+	if err != nil {
+		panic(err)
+	}
+	for i := 0; i < len(ns); i++ {
+		fmt.Printf("\t%s\t%v\n", ns[i].Namespace.ToString(), ns[i].Capability)
+	}
+
+	err = node.DocDrop(doc.Id())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Dropped document %s\n", doc.Id().ToString())
+
+	fmt.Println("List of docs and their capabilities (0-Read, 1-Write):")
+	ns, err = node.DocList()
+	if err != nil {
+		panic(err)
+	}
+	// list no longer contains the dropped doc
+	for i := 0; i < len(ns); i++ {
+		fmt.Printf("\t%s\t%v\n", ns[i].Namespace.ToString(), ns[i].Capability)
+	}
+
+	// Output
+	// Created document cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha
+	// List of docs and their capabilities (0-Read, 1-Write):
+	//   cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha	1
+	// Dropped document cilxv6cnm3w3kjyh4iqacd374435f6h27tog7j3r77wdpb4fszha
+	// List of docs and their capabilities (0-Read, 1-Write):
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/doc-export/page.mdx
+++ b/src/app/docs/api/doc-export/page.mdx
@@ -37,5 +37,214 @@ Delete document 2aoukeibc2vdy5n2? yes
 Doc 2aoukeibc2vdy5n2 has been deleted.
 ```
 
+```python {{ title: 'python' }}
+import os
+import shutil
+from iroh import IrohNode, key_to_path, path_to_key
+
+# Create folder
+os.mkdir("tmp")
+
+# Create an export directory
+os.mkdir("export")
+
+try:
+    root = os.path.abspath(os.path.join("tmp"))
+    print(f"Created dir {root}")
+
+    # Create file
+    path = os.path.join("tmp", "hello_world")
+    with open(path, "w") as f:
+        f.write("Hello World!")
+    print(f"Created file \"hello_world\"")
+
+    # Create Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Create author and document
+    author = node.author_create()
+    print(f"Created author {author.to_string()}")
+
+    doc = node.doc_create()
+    print(f"Created document {doc.id().to_string()}")
+
+    prefix = "import-example"
+
+    # Import the file
+    path = os.path.abspath(os.path.join("tmp", "hello_world"))
+    key = path_to_key(path, prefix, root)
+    print(f"key: {key.decode('utf-8')}")
+    doc.import_file(author, key, path, False, None)
+
+    # Export the file
+    # Get the entry via an exact author and key
+    entry = doc.get_exact(author, key, False)
+
+    root = os.path.abspath(os.path.join("export"))
+    print(f"root: {root}")
+
+    # Create the export path from the key, prefix, and directory location
+    export_path = key_to_path(key, prefix, root)
+
+    # Export the entry
+    doc.export_file(entry, export_path, None)
+
+    # Open the exported file and print the contents
+    with open(export_path, "r") as f:
+        content = f.read()
+    print(f"file {export_path}: {content}")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+# cleanup export dir
+shutil.rmtree("export")
+
+# Output:
+# Created dir $HOME/tmp
+# Created file "hello_world"
+# Created author 2bgy4eozp5mcrhzqm6fylwpqsm2mddqogg4yphunegll2gxtmh4q
+# Created document mu65dqhxcchrfkfm6meyllitrpayljdra4qrqy54s4sgfwlgr2tq
+# key: import-examplehello_world
+# root: $HOME/export
+# file $HOME/export/hello_world: Hello World!
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	root, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir", root)
+
+	// create file
+	path := filepath.Join("tmp", "hello_world")
+	f, err := os.Create(path)
+	if err != nil {
+		panic(err)
+	}
+	_, err = f.WriteString("Hello World!")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created file \"hello_world\"\n")
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	prefix := "import-example"
+
+	// import the file
+	path, err = filepath.Abs(filepath.Join("tmp", "hello_world"))
+	if err != nil {
+		panic(err)
+	}
+	// create a key from the path, use the `iroh.PathToKey` function to ensure
+	// that we strip the root correctly, and add any prefix we want to add for
+	// organizational purposes
+	key, err := iroh.PathToKey(path, &prefix, &root)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("key: %s\n", key)
+	err = doc.ImportFile(author, key, path, false, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// export the file
+	// get the entry via an exact author and key
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+	// create an export directory
+	if err := os.Mkdir("export", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("export")
+		fmt.Println("Removed dir 'export'")
+	}()
+	root, err = filepath.Abs(filepath.Join("export"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("root:", root)
+
+	// create the export path from the key, prefix, and directory location
+	// this allows you to strip whatever prefix you have added to the key, and
+	// add the absolute path to the relative path we used to create the key.
+	// KeyToPath is the inverse of PathToKey
+	exportPath, err := iroh.KeyToPath(key, &prefix, &root)
+	if err != nil {
+		panic(err)
+	}
+	// export the entry
+	err = doc.ExportFile(*entry, exportPath, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// open the exported file & print the contents
+	content, err := ioutil.ReadFile(exportPath)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("file %s: %q\n", exportPath, content)
+
+	// Output:
+	// Created $HOME/tmp
+	// Created file "hello_world"
+	// Created author hr6p3rrvp6ywlsitgd4djxzz67uhrb7eg2gho4zogb4e5rkpan5a
+	// Created document in66kpmbqedchn6rkzvq3ri4omren5mkid3cecjmakj23ofefpqa
+	// key: import-examplehello_world
+	// root: $HOME/export
+	// file $HOME/export/hello_world: "Hello World!"
+	// Removed dir 'export'
+	// Removed dir 'tmp'
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/doc-get/page.mdx
+++ b/src/app/docs/api/doc-get/page.mdx
@@ -51,25 +51,38 @@ bar
 ```
 
 ```python {{ title: 'python' }}
-import iroh
+from iroh import IrohNode
+import os
 
-IROH_DATA_DIR = "./iroh-data"
+# Create a new Iroh node
+node = IrohNode("iroh_data_dir")
 
-node = iroh.IrohNode(IROH_DATA_DIR)
-print("Started Iroh node: {}".format(node.node_id()))
+# Create an author
+author = node.author_create()
+print(f"Created author {author.to_string()}")
 
-author = node.author_new()
-print("Created author: {}".format(author.to_string()))
+# Create a document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+# Set content in the document
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
 
-hash = doc.set_bytes(author, bytes("foo", "utf8"), bytes("bar", "utf8"))
-print("Inserted: {}".format(hash.to_string()))
+# Get an entry from the document
+entry = doc.get_exact(author, key, False)
 
-# FIXME: this doesn't work yet
-# content = doc.get_content_bytes(hash)
-# print("Got content: {}".format(content.decode("utf8")))
+# Read content from the entry
+content = entry.content_bytes(doc)
+print(f"Got content \"{content.decode('utf-8')}\"")
+
+# Output:
+# Created author huarctxgpvq2ucnifubjxvmac7c26evzudnynp5xrugkkm37ma7q
+# Created document zmwwfsnnoxgij4q5bknfij5tpwbm2askypip3al3bahinucx65oq
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Got content "says hello"
+
 ```
 
 ```swift {{ title: 'swift' }}
@@ -90,35 +103,44 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Created author %s\n", author.ToString())
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	hash, err := doc.SetBytes(author, []byte("go"), []byte("says hello"))
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Inserted %s\n", hash.ToString())
 
-	content, err := doc.GetContentBytes(hash)
+	// returns a pointer to an entry
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+
+	// dereference the pointer to the entry once you know doc.GetExact did not
+	// return an error
+	content, err := (*entry).ContentBytes(doc)
 	if err != nil {
 		panic(err)
 	}

--- a/src/app/docs/api/doc-import/page.mdx
+++ b/src/app/docs/api/doc-import/page.mdx
@@ -49,5 +49,186 @@ bar
 
 ```
 
+```python {{ title: 'python' }}
+import os
+import shutil
+
+from iroh import IrohNode, Query, path_to_key 
+
+# Create folder
+os.mkdir("tmp")
+
+try:
+    root = os.path.abspath(os.path.join("tmp"))
+    print("Created dir \"tmp\"")
+
+    file_names = ["foo", "bar", "bat"]
+    # Create three files in the folder
+    for file_name in file_names:
+        file_path = os.path.join("tmp", file_name)
+        with open(file_path, "w") as f:
+            f.write(f"{file_name}")
+        print(f"Created file {file_path}")
+
+    # Create an Iroh node
+    node = IrohNode("iroh_data_dir")
+
+    # Create author and document
+    author = node.author_create()
+    print(f"Created author {author.to_string()}")
+
+    doc = node.doc_create()
+    print(f"Created document {doc.id().to_string()}")
+
+    prefix = "import-example"
+    # Import the files
+    for file_name in file_names:
+        path = os.path.abspath(os.path.join("tmp", file_name))
+        # create a key from the path, use the `iroh.PathToKey` function to ensure
+		# that we strip the root correctly, and add any prefix we want to add for
+		# organizational purposes
+        key = path_to_key(path, prefix, root)
+        doc.import_file(author, key, path, False, None)
+
+    # Get all the entries with default filtering and sorting
+    query = Query.all(None)
+    entries = doc.get_many(query)
+
+    print("One entry for each file:")
+    for entry in entries:
+        key = entry.key()
+        hash = entry.content_hash()
+        content = entry.content_bytes(doc)
+        print(f"{key.decode('utf-8')}: {content.decode('utf-8')} (hash: {hash.to_string()})")
+
+except Exception as e:
+    print("error: ", e)
+
+# cleanup dir
+shutil.rmtree("tmp")
+
+# Output:
+# Created dir "tmp"
+# Created file tmp/foo
+# Created file tmp/bar
+# Created file tmp/bat
+# Created author kpksn2yl2c3nlppjtnpxa2h2utmu2fdnutuwptybenr3gxdlrkiq
+# Created document af7klzttoegn6kvr7p6j7tgw6tz2w54n5bfzqvpcfmy2mrkk3pgq
+# One entry for each file:
+# import-examplebar: bar (hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu)
+# import-examplebat: bat (hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4)
+# import-examplefoo: foo (hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e)
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+func main() {
+	// create folder
+	if err := os.Mkdir("tmp", os.ModePerm); err != nil {
+		panic(err)
+	}
+	defer func() {
+		os.RemoveAll("tmp")
+		fmt.Println("Removed dir 'tmp'")
+	}()
+
+	root, err := filepath.Abs(filepath.Join("tmp"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created dir \"tmp\"")
+
+	fileNames := []string{"foo", "bar", "bat"}
+	// create three files in the folder
+	for _, fileName := range fileNames {
+		path := filepath.Join("tmp", fileName)
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		}
+		_, err = f.WriteString(fmt.Sprintf("%s", fileName))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created file %q\n", path)
+	}
+
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	prefix := "import-example"
+	// import the files
+	for _, fileName := range fileNames {
+		path, err := filepath.Abs(filepath.Join("tmp", fileName))
+		if err != nil {
+			panic(err)
+		}
+		// create a key from the path, use the `iroh.PathToKey` function to ensure
+		// that we strip the root correctly, and add any prefix we want to add for
+		// organizational purposes
+		key, err := iroh.PathToKey(path, &prefix, &root)
+		if err != nil {
+			panic(err)
+		}
+
+		doc.ImportFile(author, key, path, false, nil)
+	}
+
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("One entry for each file:")
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := entry.ContentBytes(doc)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%s: %q (hash: %s)\n", string(key), string(content), hash.ToString())
+	}
+
+	// Output:
+	// Created dir "tmp"
+	// Created file "tmp/foo"Created file "tmp/bar"Created file "tmp/bat"Created author kup6o2nnubm67rupuzo4mxjjwafpo6fbvhjjfjxdmvvm337i2txq
+	// Created document rezwubpa2pxt5ikvrwr65oifq5csnz6h3eeq7l2yrkfewo6dji2a
+	// One entry for each file:
+	// import-examplebar: "bar" (hash: bafkr4ihs5cl65v6sa3gykxkecwmpuuq2xr22vfuvh2l4amgjmewdbqjjhu)
+	// import-examplebat: "bat" (hash: bafkr4iabccdb2eyeu764xoewbcqv62sjaggxibtmxx5tnmwer3wp3rquq4)
+	// import-examplefoo: "foo" (hash: bafkr4iae4c5tt4yldi76xcpvg3etxykqkvec352im5fqbutolj2xo5yc5e)
+	// Removed dir 'tmp'
+}
+
+```
+
 
 </CodeGroup>

--- a/src/app/docs/api/doc-join/page.mdx
+++ b/src/app/docs/api/doc-join/page.mdx
@@ -37,18 +37,19 @@ tiqpal5qnrb3idy7g4n7hnh5esex7zu6jtqyuwt6hr4iq2nnlpua
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 # you'll need to get a ticket from somewhere, see the `doc share` command documentation
 # for details. This ticket will fail to join, but is a valid ticket.
-TICKET_STRING = "sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg"
+TICKET_STRING = "docaaa7qg6afc6zupqzfxmu5uuueaoei5zlye7a4ahhrfhvzjfrfewozgybl5kkl6u6fqcnjxvdkoihq3nbsqczxeulfsqvatb2qh3bwheoyahacitior2ha4z2f4xxk43fgewtcltemvzhaltjojxwqltomv2ho33snmxc6biajjeteswek4ambkabzpcfoajganyabbz2zplaaaaaaaaaagrjyvlqcjqdoaaioowl2ygi2likyov62rofk4asma3qacdtvs6whqsdbizopsefrrkx"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
 doc_ticket = iroh.DocTicket.from_string(TICKET_STRING)
 doc = node.doc_join(doc_ticket)
-print("Joined doc: {}".format(doc.id()))
+print("Joined doc: {}".format(doc.id().to_string()))
+
 ```
 
 ```swift {{ title: 'go' }}
@@ -57,15 +58,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 // you'll need to get a ticket from somewhere, see the `doc share` command documentation
-// for details. This ticket will fail to join, but is a valid ticket.
-const ticketString = "sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg"
+// for details.
+
+const ticketString = "docaaa7qg6afc6zupqzfxmu5uuueaoei5zlye7a4ahhrfhvzjfrfewozgybl5kkl6u6fqcnjxvdkoihq3nbsqczxeulfsqvatb2qh3bwheoyahacitior2ha4z2f4xxk43fgewtcltemvzhaltjojxwqltomv2ho33snmxc6biajjeteswek4ambkabzpcfoajganyabbz2zplaaaaaaaaaagrjyvlqcjqdoaaioowl2ygi2likyov62rofk4asma3qacdtvs6whqsdbizopsefrrkx"
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +82,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Joined doc: %s", doc.Id())
+	fmt.Println("Joined doc:", doc.Id().ToString())
 }
 
 ```

--- a/src/app/docs/api/doc-keys/page.mdx
+++ b/src/app/docs/api/doc-keys/page.mdx
@@ -59,25 +59,39 @@ author:i3vpd4e7… doc:njszszvg…
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 for i, key in enumerate(['a', 'b', 'c']):
     doc.set_bytes(author, bytes(key, "utf8"), bytes(str(i), "utf8"))
 
-keys = doc.keys()
+# get all the entries with default filtering and sorting
+query = iroh.Query.all(None)
+entries = doc.get_many(query)
 print("Keys:")
-for key in keys:
-    content = doc.get_content_bytes(key)
-    print("{} : {} (hash: {})".format(key.key(), content.decode("utf8"), key.hash().to_string()))
+for entry in entries:
+    key = entry.key()
+    hash = entry.content_hash()
+    content = entry.content_bytes(doc)
+    print("{} : {} (hash: {})".format(key, content.decode("utf8"), hash.to_string()))
+
+# Output:
+# Started Iroh node: f5seybgjqa4yrnqbhcibxyckykzile76ygfnpqhslpjzlztssrlq
+# Created author: sf6zsxtzdsbrofaghjhso3czyyfciipxxldplhfkbc34abqmtbha
+# Created doc: sqsx7kn3nfvjhziwhcjnoa47fpisbqtox4363nf4uxzhxwehxnba
+# Keys:
+# b'a' : 0 (hash: bafkr4icnazyvhldstjfh5arazf4tl752m5ehqygvqkmm52zdqzbwtbt5t4)
+# b'b' : 1 (hash: bafkr4igwhpm2qjvpsha75i3rszngjyi64ihrhzdll5jmlgibcntalm5eq4)
+# b'c' : 2 (hash: bafkr4iebh2nxfekb47zyll5aulin6ptmg6e6ij774sxo6vtkkzn4r4x6hu)
+
 ```
 
 ```swift {{ title: 'go' }}
@@ -86,25 +100,25 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	for i, key := range []string{"a", "b", "c"} {
 		if _, err := doc.SetBytes(author, []byte(key), []byte(fmt.Sprintf("%d", i))); err != nil {
@@ -112,18 +126,22 @@ func main() {
 		}
 	}
 
-	keys, err := doc.Keys()
+	// get all the entries with default filtering and sorting
+	query := iroh.QueryAll(nil)
+	entries, err := doc.GetMany(query)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Println("Keys:")
-	for _, key := range keys {
-		content, err := doc.GetContentBytes(key)
+	for _, entry := range entries {
+		key := entry.Key()
+		hash := entry.ContentHash()
+		content, err := entry.ContentBytes(doc)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("%q : %q (hash: %s)\n", string(key.Key()), string(content), key.Hash().ToString())
+		fmt.Printf("%q : %q (hash: %s)\n", string(key), string(content), hash.ToString())
 	}
 	// Output:
 	// Created document 7hgonoxdjzlwtuicfyou24l5nhv3bmvzhyeq6v2er66ekrpvhotq

--- a/src/app/docs/api/doc-list/page.mdx
+++ b/src/app/docs/api/doc-list/page.mdx
@@ -31,24 +31,34 @@ List documents on this node. {{ className: 'lead' }}
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
 # create a document
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 # create a second document
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
 # list all your documents
 docs = node.doc_list();
 print("List all {} docs:".format(len(docs)))
-for doc in docs:
-    print("\t{}".format(doc.to_string()))
+# doc ids are also called "namespace ids"
+for namespace_and_capability in docs:
+    print("\t{}".format(namespace_and_capability.namespace.to_string()))
+
+# Output:
+# Started Iroh node: jplmb4cgk2pxw3dwjehk7oes7ddphftlh3vdiib4e5bwhq2nnokq
+# Created doc: mr42ra4f6n63kkd6kmqghgonsanqqtpv5cvkgcu7bpg2zaauimrq
+# Created doc: n4w6eip5cgxlv33dl3nln544km76t4gt2etpml6kc6qpo6sqmdua
+# List all 2 docs:
+# 	mr42ra4f6n63kkd6kmqghgonsanqqtpv5cvkgcu7bpg2zaauimrq
+# 	n4w6eip5cgxlv33dl3nln544km76t4gt2etpml6kc6qpo6sqmdua
+
 
 ```
 
@@ -58,29 +68,29 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
 	// create one document
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	// create a second document
-	doc, err := node.DocNew()
+	doc, err = node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
 	// list all your documents
 	docs, err := node.DocList()
@@ -89,8 +99,9 @@ func main() {
 	}
 
 	fmt.Printf("Listing all %d documents:\n", len(docs))
-	for _, doc_id := range docs {
-		fmt.Printf("\t%s\n", doc_id.ToString())
+	// doc ids are also called "NamespaceIds"
+	for _, namespaceAndCapability := range docs {
+		fmt.Printf("\t%s\n", namespaceAndCapability.Namespace.ToString())
 	}
 }
 

--- a/src/app/docs/api/doc-new/page.mdx
+++ b/src/app/docs/api/doc-new/page.mdx
@@ -29,16 +29,17 @@ ktrygcpxealfdtfmohw66nb2keivu52opk65cyj4j7jy7wior7ea
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
+
 ```
 
 ```swift {{ title: 'go' }}
@@ -47,21 +48,21 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 }
 
 ```

--- a/src/app/docs/api/doc-set/page.mdx
+++ b/src/app/docs/api/doc-set/page.mdx
@@ -52,25 +52,38 @@ $ iroh doc 674deec7a19fec50fd6f486a5eef20509073ecf7c527b60a27c84baea90d3816 set 
 ```
 
 ```python {{ title: 'python' }}
-import iroh
+from iroh import IrohNode
+import os
 
-IROH_DATA_DIR = "./iroh-data"
+# Create a new Iroh node
+node = IrohNode("iroh_data_dir")
 
-node = iroh.IrohNode(IROH_DATA_DIR)
-print("Started Iroh node: {}".format(node.node_id()))
+# Create an author
+author = node.author_create()
+print(f"Created author {author.to_string()}")
 
-author = node.author_new()
-print("Created author: {}".format(author.to_string()))
+# Create a document
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+# Set content in the document
+key = b"python"
+hash = doc.set_bytes(author, key, b"says hello")
+print(f"Inserted {hash.to_string()}")
 
-hash = doc.set_bytes(author, bytes("foo", "utf8"), bytes("bar", "utf8"))
-print("Inserted: {}".format(hash.to_string()))
+# Get an entry from the document
+entry = doc.get_exact(author, key, False)
 
-# FIXME: this doesn't work yet
-# content = doc.get_content_bytes(hash)
-# print("Got content: {}".format(content.decode("utf8")))
+# Read content from the entry
+content = entry.content_bytes(doc)
+print(f"Got content \"{content.decode('utf-8')}\"")
+
+# Output:
+# Created author huarctxgpvq2ucnifubjxvmac7c26evzudnynp5xrugkkm37ma7q
+# Created document zmwwfsnnoxgij4q5bknfij5tpwbm2askypip3al3bahinucx65oq
+# Inserted bafkr4ihasgdyqs6onufsjrmk5h5vcg2ud75u2iaokavwiulyg7wfno6fte
+# Got content "says hello"
+
 ```
 
 ```swift {{ title: 'swift' }}
@@ -91,35 +104,44 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		// real programs handle errors!
 		panic(err)
 	}
 
-	author, err := node.AuthorNew()
+	author, err := node.AuthorCreate()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Created author %s\n", author.ToString())
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	hash, err := doc.SetBytes(author, []byte("go"), []byte("says hello"))
+	key := []byte("go")
+	hash, err := doc.SetBytes(author, key, []byte("says hello"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Inserted %s\n", hash.ToString())
 
-	content, err := doc.GetContentBytes(hash)
+	// returns a pointer to an entry
+	entry, err := doc.GetExact(author, key, false)
+	if err != nil {
+		panic(err)
+	}
+
+	// dereference the pointer to the entry once you know doc.GetExact did not
+	// return an error
+	content, err := (*entry).ContentBytes(doc)
 	if err != nil {
 		panic(err)
 	}

--- a/src/app/docs/api/doc-share/page.mdx
+++ b/src/app/docs/api/doc-share/page.mdx
@@ -48,19 +48,30 @@ gjfmivyaycuads6ek4asma3qacdtvs6waaaaaaaaaanctrkxaetag4aaq45mprsyystlwe66csxvqmru
 ```python {{ title: 'python' }}
 import iroh
 
-IROH_DATA_DIR = "./iroh-data"
+IROH_DATA_DIR = "./iroh_data_dir"
 
 node = iroh.IrohNode(IROH_DATA_DIR)
 print("Started Iroh node: {}".format(node.node_id()))
 
-author = node.author_new()
+author = node.author_create()
 print("Created author: {}".format(author.to_string()))
 
-doc = node.doc_new()
-print("Created doc: {}".format(doc.id()))
+doc = node.doc_create()
+print("Created doc: {}".format(doc.id().to_string()))
 
-ticket = doc.share_write()
+ticket = doc.share(iroh.ShareMode.READ)
+print("Read-Access Ticket: {}".format(ticket.to_string()))
+
+ticket = doc.share(iroh.ShareMode.WRITE)
 print("Write-Access Ticket: {}".format(ticket.to_string()))
+
+# Output:
+# Started Iroh node: rwgutd2wazt756h5awh6x576jejizai6w2l6ae5gxsv7tpswmopq
+# Created author: ivn4qsyq3utro5px6k5k5hnbpp6eqh6l5u667hpkgbsglpadfowq
+# Created doc: ijgvnoxfgkkgze3cyb7rwjywfqvfzy2pzilo2tn5wf64fgm7nxkq
+# Read-Access Ticket: docafbe2vv24uzji3etmlah6gzhcywcuxhdj7fbn3knxwyx3quzt5w5kajarwgutd2wazt756h5awh6x576jejizai6w2l6ae5gxsv7tpswmopqcaifabfesmskyrlqbqfiahf4ivybeybxaaehhlf5maaaaaaaaaa2fhcvoajganyabbz2zplazdjnblb2x3kfyvlqcjqdoaaioowl2zctm6q34dlgzp6fk4
+# Write-Access Ticket: docaaqo2dtt7udula5vvevfwjenux3tk3l3lfpefugeu6r6v55pwusvc5qbecgy2smpkydgp7xy7ucy727x7zerfdebd23jpyatu26kx6n6kzrz6aibauaeusjsjlcfoagavaa4xrcxaetag4aaq45mxvqaaaaaaaaadiu4kvybeybxaaehhlf5mdenfufmhk7nixcvoajganyabbz2zpleknt2dpqnm3f7yvlq
+
 ```
 
 ```swift {{ title: 'go' }}
@@ -69,36 +80,36 @@ package main
 import (
 	"fmt"
 
-	"github.com/n0-computer/iroh-ffi/iroh"
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
 )
 
 func main() {
-	node, err := iroh.NewIrohNode()
+	node, err := iroh.NewIrohNode("iroh_data_dir")
 	if err != nil {
 		panic(err)
 	}
 
-	doc, err := node.DocNew()
+	doc, err := node.DocCreate()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created document %s\n", doc.Id())
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
 
-	// TODO - sharing read-only tickets is not yet implemented. Coming soon!
-	// readTicket, err := doc.ShareRead()
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// fmt.Println(readTicket.ToString())
-
-	writeTicket, err := doc.ShareWrite()
+	readTicket, err := doc.Share(iroh.ShareModeRead)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Write-Access Ticket: %s", writeTicket.ToString())
+	fmt.Println("Read-Access Ticket:", readTicket.ToString())
+
+	writeTicket, err := doc.Share(iroh.ShareModeWrite)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Write-Access Ticket:", writeTicket.ToString())
 	// Output:
 	// Created document 7hgonoxdjzlwtuicfyou24l5nhv3bmvzhyeq6v2er66ekrpvhotq
-	// Write-Access Ticket: sdx7wazju2rysqydgfpmhqkrluc5lbcuainravjipwmbl7r3k3uqcigncyopdcnooufnteu5vuatpzhoqrml35ifgyuozr6kwhjiz4jxyaaqcbiajbmsainmsmbqcjqaibavg5hiaaaaaaaaaaabad47sebqbqfiiqzkzeydadakqrckvsjqgajgabaecu3u5aaaaaaaaaaaaeagt6iqg
+	// Read-Access Ticket: docahabhyiz37wlugkwb6cj424qparg6tz5ujmxpr6ac3rkbkvgjys3qajabdmaailylilvvj5ejqcaaa5gkz6pehua4vbu26bbjit2h7axb3lacaidaafakaacyrlqbooyzfgmivyaycuacioek4
+	// Write-Access Ticket: docaaqbt3lfrlih4yncth3rdwta4doendvv7e3fqtt27l6lf5tsfs6mqsibeaenqabbpbnbowvhurgaiaaduzlhz4q6qdsugtlyeffcpi74c4hnmaibamaaubiaalcfoafz3deuzrcxadakqajbyrlq
 }
 
 ```

--- a/src/app/docs/api/doc-watch/page.mdx
+++ b/src/app/docs/api/doc-watch/page.mdx
@@ -37,5 +37,150 @@ author:i3vpd4e7… doc:njszszvg…
   # events will show up here!
 ```
 
+```python {{ title: 'python' }}
+import queue
+from iroh import IrohNode, LiveEventType
+
+class Watch:
+    def __init__(self, queue):
+        self.queue = queue
+
+    def event(self, e):
+        t = e.type()
+        if t == LiveEventType.INSERT_LOCAL:
+            entry = e.as_insert_local()
+            print(f"LiveEvent - InsertLocal: entry hash {entry.content_hash().to_string()}")
+            self.queue.put(True)
+        elif t == LiveEventType.INSERT_REMOTE:
+            insert_remove_event = e.as_insert_remote()
+            print(f"LiveEvent - InsertRemote:\n\tfrom: {insert_remove_event.from_}\n\tentry hash:\n\t{insert_remove_event.entry.content_hash().to_string()}\n\tcontent_status: {insert_remove_event.content_status}")
+            print("Insert Remove events will be eventually followed by the ContentReady event")
+        elif t == LiveEventType.CONTENT_READY:
+            hash_val = e.as_content_ready()
+            print(f"LiveEvent - ContentReady: hash {hash_val.to_string()}")
+        elif t == LiveEventType.NEIGHBOR_UP:
+            node_id = e.as_neighbor_up()
+            print(f"LiveEvent - NeighborUp: node id {node_id.to_string()}")
+        elif t == LiveEventType.NEIGHBOR_DOWN:
+            node_id = e.as_neighbor_down()
+            print(f"LiveEvent - NeighborDown: node id {node_id.to_string()}")
+        elif t == LiveEventType.SYNC_FINISHED:
+            sync_event = e.as_sync_finished()
+            print(f"Live Event - SyncFinished: synced peer: {sync_event.peer.to_string()}")
+        else:
+            raise Exception("unknown LiveEventType")
+
+# Create Iroh node
+node = IrohNode("iroh_data_dir")
+
+# Create author and document
+author = node.author_create()
+print(f"Created author {author.to_string()}")
+
+doc = node.doc_create()
+print(f"Created document {doc.id().to_string()}")
+
+# Create a queue for synchronization
+event_queue = queue.Queue()
+
+callback = Watch(event_queue)
+doc.subscribe(callback)
+
+key = b"watch-me"
+doc.set_bytes(author, key, b"I'm going to trigger an InsertLocal event.")
+
+# Wait for the watcher to get the insert local event
+event_queue.get()
+
+print("Done!")
+
+# Output:
+# Created author 4zxg622q75rko5t4nqgxpe7mznavaajquwcjwrknoia6s2fu2sja
+# Created document 3h6ea3d6ucs3iicwn2hzovpwhh3lpchs7b6nt5byoci3aqt6amfa
+# LiveEvent - InsertLocal: entry hash bafkr4ic24i3eenzjflowjva7e2tyw24yafro5kvve6p6ziwics5kc2id5e
+# Done!
+
+```
+
+```swift {{ title: 'go' }}
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/n0-computer/iroh-ffi/iroh-go/iroh"
+)
+
+type watch struct {
+	wg *sync.WaitGroup
+}
+
+func (w watch) Event(e *iroh.LiveEvent) *iroh.IrohError {
+	switch t := e.Type(); t {
+	case iroh.LiveEventTypeInsertLocal:
+		// returns the entry from the InsertLocal event
+		entry := e.AsInsertLocal()
+		fmt.Println("LiveEvent - InsertLocal: entry hash", entry.ContentHash().ToString())
+		w.wg.Done()
+	case iroh.LiveEventTypeInsertRemote:
+		insertRemoveEvent := e.AsInsertRemote()
+		fmt.Printf("LiveEvent - InsertRemote:\n\tfrom: %s\n\tentry hash:\n\tcontent_status: %v\n", insertRemoveEvent.From, insertRemoveEvent.Entry.ContentHash().ToString(), insertRemoveEvent.ContentStatus)
+		fmt.Println("Insert Remove events will be eventually followed by the ContentReady event")
+	case iroh.LiveEventTypeContentReady:
+		hash := e.AsContentReady()
+		fmt.Println("LiveEvent - ContentReady: hash", hash.ToString())
+	case iroh.LiveEventTypeNeighborUp:
+		nodeId := e.AsNeighborUp()
+		fmt.Println("LiveEvent - NeighborUp: node id", nodeId.ToString())
+	case iroh.LiveEventTypeNeighborDown:
+		nodeId := e.AsNeighborDown()
+		fmt.Println("LiveEvent - NeighborDown: node id", nodeId.ToString())
+	case iroh.LiveEventTypeSyncFinished:
+		syncEvent := e.AsSyncFinished()
+		fmt.Println("Live Event - SyncFinished: synced peer:", syncEvent.Peer.ToString())
+	default:
+		return &iroh.IrohError{}
+	}
+	return nil
+}
+
+func main() {
+	node, err := iroh.NewIrohNode("iroh_data_dir")
+	if err != nil {
+		panic(err)
+	}
+
+	author, err := node.AuthorCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created author %s\n", author.ToString())
+
+	doc, err := node.DocCreate()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created document %s\n", doc.Id().ToString())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	callback := watch{wg: &wg}
+
+	err = doc.Subscribe(callback)
+
+	key := []byte("watch-me")
+	_, err = doc.SetBytes(author, key, []byte("I'm going to trigger an InsertLocal event."))
+	if err != nil {
+		panic(err)
+	}
+
+	// wait for the watcher to get the insert local event
+	wg.Wait()
+	fmt.Println("Done!")
+}
+
+```
+
 
 </CodeGroup>


### PR DESCRIPTION
adds rust and python tests for all associated `iroh` cli commands

also adds a readme explaining how to run the examples