### PR TITLE
Fix broken link iroh-examples repo

### DIFF
--- a/src/app/docs/examples/page.mdx
+++ b/src/app/docs/examples/page.mdx
@@ -5,7 +5,7 @@ import { Examples } from '@/components/Examples'
 Learn by examining practical code examples. We try to collage together examples to show a broad range of platforms & techniques while working with iroh.{{className: 'lead'}}
 
 <Note>
-  The [iroh examples repo](https://github.com/iroh-examples) has a grab bag of extra examples. Post an issue there if you have a request for a specific example, or [join the discord](https://iroh.computer/discord).
+  The [iroh examples repo](https://github.com/n0-computer/iroh-examples) has a grab bag of extra examples. Post an issue there if you have a request for a specific example, or [join the discord](https://iroh.computer/discord).
 </Note>
 
 <Examples />


### PR DESCRIPTION
The link to examples repo is broken at https://iroh.computer/docs/examples. It's https://github.com/iroh-examples (notice lack of organization in URL) instead of https://github.com/n0-computer/iroh-examples