### PR TITLE
Fix grammar in introduction

### DIFF
--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -17,7 +17,7 @@ export const sections = [
 
 # Iroh Documentation
 
-Iroh is a protocol for syncing bytes. Bytes of any size, across any number of devices. Use iroh to create apps that scale different. {{className: 'lead'}}
+Iroh is a protocol for syncing bytes. Bytes of any size, across any number of devices. Use iroh to create apps that scale differently. {{className: 'lead'}}
 
 <div className="not-prose">
   <div className="mb-16 mt-6 flex gap-3">


### PR DESCRIPTION
Feel free to ignore this if this was intentional,
but 'different' modifies a verb 'scale' and thus should be an adverb 'differently'.