### PR TITLE
Update TODO example links

### DIFF
--- a/src/app/docs/sdks/rust/page.mdx
+++ b/src/app/docs/sdks/rust/page.mdx
@@ -76,7 +76,7 @@ The [API documentation](https://docs.rs/iroh/) is the best place to learn about 
     pattern={{ y: 24, squares: [[-1, 2], [1, 3]] }}
     />
   <Resource
-    href='https://github.com/n0-computer/iroh-example-todos'
+    href='https://github.com/n0-computer/iroh-examples/tree/main/tauri-todos'
     name='todos app example'
     description='A sample app built with iroh in rust & Tauri'
     icon='CodeBracketIcon'

--- a/src/components/Examples.jsx
+++ b/src/components/Examples.jsx
@@ -12,7 +12,7 @@ import { Tag } from './Tag';
 const examples = [
   {
     // TODO: finish TODOs docs page, switch this href for "/docs/examples/todos"
-    href: 'https://github.com/n0-computer/iroh-example-todos',
+    href: 'https://github.com/n0-computer/iroh-examples/tree/main/tauri-todos',
     name: 'Todos',
     description:
       'See iroh in the classic TODO app example, with a CLI & desktop GUI.',


### PR DESCRIPTION
Updates links to the Iroh TODO example to point to https://github.com/n0-computer/iroh-examples/tree/main/tauri-todos instead of archived repo https://github.com/n0-computer/iroh-example-todos