### PR TITLE
Update CLI command example usage

### DIFF
--- a/api-code-examples/api.mjs
+++ b/api-code-examples/api.mjs
@@ -88,7 +88,7 @@ author:fhu3uk4w… doc:dyyelvqq…
 @fhu3uk4w…: foo = 6lujp3wx… (3 B)
 
 author:fhu3uk4w… doc:dyyelvqq…
-> doc get foo -c
+> doc get foo
 @fhu3uk4w…: foo = 6lujp3wx… (3 B)
 bar
 

--- a/src/app/docs/api/doc-get/page.mdx
+++ b/src/app/docs/api/doc-get/page.mdx
@@ -43,7 +43,7 @@ author:fhu3uk4w… doc:dyyelvqq…
 @fhu3uk4w…: foo = 6lujp3wx… (3 B)
 
 author:fhu3uk4w… doc:dyyelvqq…
-> doc get foo -c
+> doc get foo
 @fhu3uk4w…: foo = 6lujp3wx… (3 B)
 bar
 

--- a/src/app/docs/quickstart/page.mdx
+++ b/src/app/docs/quickstart/page.mdx
@@ -146,7 +146,7 @@ x5qffedimrovdpsr3andm3hdjo6g2nlaqstdm6oe3utblxsdh3eq
 Active doc is now x5qffedimrovdpsr
 
 author:ksdx5fs4kwjmoaca doc:x5qffedimrovdpsr
-> doc get foo -c
+> doc get foo
 @fhu3uk4wc2hl2e45: foo = "bar" (3 B)
 
 author:ksdx5fs4kwjmoaca doc:x5qffedimrovdpsr


### PR DESCRIPTION
In a few places the documentation uses `doc get foo -c` the `-c` flag is no longer a valid flag for the `doc get` command. Replaces this CLI example usage with `doc get foo`