### PR TITLE
Add section about documents storage and reference API and SDK

### DIFF
--- a/src/app/docs/layers/documents/page.mdx
+++ b/src/app/docs/layers/documents/page.mdx
@@ -69,4 +69,12 @@ Every document is its own pubsub swarm, keyed by the public key of the document.
 Bartosz Sypytkowski has a great [blog post](https://www.bartoszsypytkowski.com/hyparview/) on HyParView & Plumtree, well worth reading.
 </Note>
 
-As authors write to a document, they publish these changes as pubsub messages that other peers pick up on & apply to their local state.
+As authors write to a document, they publish these changes as pubsub messages that other peers pick up on & apply to their local state
+
+## Storage
+
+Iroh docs can be used with in-memory or file-system based storage. The store is used to keep track of all relevant metadata necessary for management of documents, authors and keys. The contents associated to keys is managed by [`iroh-blobs`](/docs/layers/blobs), which stores data in a optimized, content-addressed manner. Data can be imported and exported out of Iroh's storage using [`doc import`](/docs/api/docs-import) and [`doc export`](/docs/api/docs-export).
+
+## API
+
+Documents can be manipulated and queried using the [docs API](/docs/api), also available via our various [official SDKs](/docs/sdks).

--- a/src/app/docs/layers/documents/page.mdx
+++ b/src/app/docs/layers/documents/page.mdx
@@ -69,7 +69,7 @@ Every document is its own pubsub swarm, keyed by the public key of the document.
 Bartosz Sypytkowski has a great [blog post](https://www.bartoszsypytkowski.com/hyparview/) on HyParView & Plumtree, well worth reading.
 </Note>
 
-As authors write to a document, they publish these changes as pubsub messages that other peers pick up on & apply to their local state
+As authors write to a document, they publish these changes as pubsub messages that other peers pick up on & apply to their local state.
 
 ## Storage
 


### PR DESCRIPTION
Add small section about document storage. I went with a rather concise description. Since to make this more useful I need to reference some parts of the API I thought it best to include a link to those relevant sections as well.

Part of the objective here is to link docs to blobs, since those are listed as layers but the connection is not mentioned anywhere. Also link the api, which has already a reference back to the docs concept.