### PR TITLE
Rework the networking section

### DIFF
--- a/src/app/docs/layers/networking/page.mdx
+++ b/src/app/docs/layers/networking/page.mdx
@@ -9,18 +9,62 @@ At the core of iroh is the ability to connect _any_ two devices, no matter where
 
 ## Nodes
 
-An iroh network is a collection of _nodes_. A node is a running process that might accept connections from other nodes on a given port. Multiple nodes can be run on the same physical device, but not the same port.
+On layer 0 an iroh network is a collection of nodes.
 
-A node has a cryptographic keypair used for signing messages. Nodes are uniquely identified by the public portion of their keypair.
+The primary functionality of the networking is to establish connections between two nodes,
+regardless of where they are located.
+To make this feasible the nodes are addressed by *NodeId* rather than by IP address and port.
+The *NodeId* is created from the public portion of a cryptographic keypair use for signing messages.
+
+A node still needs to bind to an IP address and port to be reachable,
+and IP addresses are still part of the addressing,
+though not the primary addressing mechanism.
+Multiple nodes can run on the same machine,
+but not share the same port.
+
+Networking nodes are created and controlled by the [Endpoint] struct in the `iroh-net` library.
+Often wrapped in the higher abstraction provided by [Node],
+when using multiple of iroh's layers together.
+
+[Endpoint]: https://docs.rs/iroh/latest/iroh/net/struct.Endpoint.html
+[Node]: https://docs.rs/iroh/latest/iroh/node/struct.Node.html
 
 ## Connections
 
-An iroh connection is a [QUIC](https://en.wikipedia.org/wiki/QUIC) connection running on a _MagicSocket_. QUIC is a modern transport protocol that provides a reliable, encrypted, multiplexed connection between two nodes. QUIC is built on top of UDP, and is designed to be used in situations where TCP is not a good fit (such as mobile networks).
+An iroh connection uses [QUIC] as the transport protocol,
+exposing a full QUIC API to application developers.
+QUIC is a modern transport protocol that provides a reliable, encrypted, multiplexed connection between two nodes.
+QUIC is build on top of UDP,
+and is designed to deal with a wider variety of network situations than TCP.
 
-## MagicSockets
+Iroh integrates with QUIC and the UDP transport to create direct connections between nodes.
+It dynamically routes the QUIC UDP packets via the best path to the peer,
+regularly performing latency probes to find the best path between nodes.
+Typically a connection starts relayed to ensure immediate connectivity.
+Iroh than coordinates [holepunching] to establish a direct connection between peers,
+once the direct connection exists the QUIC connection is seemlessly routed over it.
+When the network situation changes iroh quicly adapts to the new routes and seemlessly moves the connection over.
 
-Connections in iroh have a _MagicSocket_ sitting between QUIC and the operating system socket (the "real socket"). The MagicSocket simulates a connection for the quic transport, and dynamically optimizes the connection path between two nodes as connections are negotiated & optimized. The MagicSocket will perform _interactive connectivity establishment_ (ICE), using an advertised set of connection details to audition connections. The MagicSocket will perform latency probes for any viable connections, switching to find the fastest ping.
+For connections where no holepunching is needed iroh can establish a conection without a relay server.
+For this the application can explicitly provide IP addressing information for a peer node,
+or rely on a pluggable discovery mechanism.
+
+[QUIC]: https://en.wikipedia.org/wiki/QUIC
+[holepunching]: https://en.wikipedia.org/wiki/Hole_punching_(networking)
 
 ## Relays
 
-Sometimes it isn't possible to establish a direct connection between two nodes, often because of strict firewall rules or NAT configurations. In these cases the only fallback is to _relay_ traffic through a third node that both nodes can connect to. Instead of sending packets directly from one node to the other, packets in either direction are first sent to the relay node, which forwards packets on to their destination. All QUIC traffic is encrypted, and relayed traffic is no exception. The relaying server _cannot_ inspect the contents of the packets being forwarded. 
+The relay server is an important component to ensure a connection can be established swiftly between any two iroh nodes,
+regardless of their location.
+It helps when strict firewall rules or NAT configurations are on the network path.
+As the relay server is publicly reachable by all nodes it can pass UDP packets between nodes until they manage to establish a direct connection.
+It also plays a vital role in the [holepunching] by informing nodes of their networking situation and coordinating between nodes.
+
+Since all traffic between nodes is encrypted for the destination node only,
+relay servers have very little knowledge and _cannot_ inspect the contents of forwarded packets.
+
+## API docs
+
+See the [reference documentation] for more technical details and the API provided.
+
+[reference documentation]: https://docs.rs/iroh/latest/iroh/net/index.html

--- a/src/app/docs/layers/networking/page.mdx
+++ b/src/app/docs/layers/networking/page.mdx
@@ -45,7 +45,7 @@ Iroh than coordinates [holepunching] to establish a direct connection between pe
 once the direct connection exists the QUIC connection is seemlessly routed over it.
 When the network situation changes iroh quicly adapts to the new routes and seemlessly moves the connection over.
 
-For connections where no holepunching is needed iroh can establish a conection without a relay server.
+For connections where no holepunching is needed iroh can establish a connection without a relay server.
 For this the application can explicitly provide IP addressing information for a peer node,
 or rely on a pluggable discovery mechanism.
 

--- a/src/app/docs/layers/networking/page.mdx
+++ b/src/app/docs/layers/networking/page.mdx
@@ -9,59 +9,42 @@ At the core of iroh is the ability to connect _any_ two devices, no matter where
 
 ## Nodes
 
-On layer 0 an iroh network is a collection of nodes.
+The primary functionality of the networking is to establish connections between two nodes, regardless of where they are located. To make this feasible the nodes are addressed by *NodeId* rather than by IP address and port. The *NodeId* is created from the public portion of a cryptographic keypair use for signing messages.
 
-The primary functionality of the networking is to establish connections between two nodes,
-regardless of where they are located.
-To make this feasible the nodes are addressed by *NodeId* rather than by IP address and port.
-The *NodeId* is created from the public portion of a cryptographic keypair use for signing messages.
+A node still needs to bind to an IP address and port to be reachable, and IP addresses are still part of the addressing, though not the primary addressing mechanism. Multiple nodes can run on the same machine, but not share the same port.
 
-A node still needs to bind to an IP address and port to be reachable,
-and IP addresses are still part of the addressing,
-though not the primary addressing mechanism.
-Multiple nodes can run on the same machine,
-but not share the same port.
+<Note>
+[This blog post](/blog/iroh-dns) outlines how we resolve raw `nodeID`s to IP addresses and ports.
+</Note>
 
 Networking nodes are created and controlled by the [Endpoint] struct in the `iroh-net` library.
 Often wrapped in the higher abstraction provided by [Node],
 when using multiple of iroh's layers together.
+
+On layer 0 an iroh network is a collection of nodes. By default an node does **not** dial out to 
+other nodes, but waits for incoming connections. Instead actions like joining a document or 
+subscribing to a gossip topic will kick of connections to nodes in the same document or topic.
 
 [Endpoint]: https://docs.rs/iroh/latest/iroh/net/struct.Endpoint.html
 [Node]: https://docs.rs/iroh/latest/iroh/node/struct.Node.html
 
 ## Connections
 
-An iroh connection uses [QUIC] as the transport protocol,
-exposing a full QUIC API to application developers.
-QUIC is a modern transport protocol that provides a reliable, encrypted, multiplexed connection between two nodes.
-QUIC is build on top of UDP,
-and is designed to deal with a wider variety of network situations than TCP.
+An iroh connection uses [QUIC] as the transport protocol, exposing a full QUIC API to application developers. QUIC is a modern transport protocol that provides a reliable, encrypted, multiplexed connection between two nodes. QUIC is build on top of UDP, and is designed to deal with a wider variety of network situations than TCP.
 
-Iroh integrates with QUIC and the UDP transport to create direct connections between nodes.
-It dynamically routes the QUIC UDP packets via the best path to the peer,
-regularly performing latency probes to find the best path between nodes.
-Typically a connection starts relayed to ensure immediate connectivity.
-Iroh than coordinates [holepunching] to establish a direct connection between peers,
-once the direct connection exists the QUIC connection is seemlessly routed over it.
-When the network situation changes iroh quicly adapts to the new routes and seemlessly moves the connection over.
+Iroh integrates with QUIC and the UDP transport to create direct connections between nodes. It dynamically routes the QUIC UDP packets via the best path to the peer, regularly performing latency probes to find the best path between nodes. Typically a connection starts relayed to ensure immediate connectivity. Iroh than coordinates [holepunching] to establish a direct connection between peers,
+once the direct connection exists the QUIC connection is seemlessly routed over it. When the network situation changes iroh quicly adapts to the new routes and seemlessly moves the connection over.
 
-For connections where no holepunching is needed iroh can establish a connection without a relay server.
-For this the application can explicitly provide IP addressing information for a peer node,
-or rely on a pluggable discovery mechanism.
+For connections where no holepunching is needed iroh can establish a connection without a relay server. For this the application can explicitly provide IP addressing information for a peer node, or rely on a pluggable discovery mechanism.
 
 [QUIC]: https://en.wikipedia.org/wiki/QUIC
 [holepunching]: https://en.wikipedia.org/wiki/Hole_punching_(networking)
 
 ## Relays
 
-The relay server is an important component to ensure a connection can be established swiftly between any two iroh nodes,
-regardless of their location.
-It helps when strict firewall rules or NAT configurations are on the network path.
-As the relay server is publicly reachable by all nodes it can pass UDP packets between nodes until they manage to establish a direct connection.
-It also plays a vital role in the [holepunching] by informing nodes of their networking situation and coordinating between nodes.
+The relay server is an important component to ensure a connection can be established swiftly between any two iroh nodes, regardless of their location. It helps when strict firewall rules or NAT configurations are on the network path. As the relay server is publicly reachable by all nodes it can pass UDP packets between nodes until they manage to establish a direct connection. It also plays a vital role in the [holepunching] by informing nodes of their networking situation and coordinating between nodes.
 
-Since all traffic between nodes is encrypted for the destination node only,
-relay servers have very little knowledge and _cannot_ inspect the contents of forwarded packets.
+Since all traffic between nodes is encrypted for the destination node only, relay servers have very little knowledge and _cannot_ inspect the contents of forwarded packets.
 
 ## API docs
 

--- a/src/components/Guides.jsx
+++ b/src/components/Guides.jsx
@@ -19,8 +19,8 @@ const guides = [
       'Documents point to blobs: opaque bytes identified by their hash',
   },
   {
-    href: '/docs/layers/connections',
-    name: 'Connections',
+    href: '/docs/layers/networking',
+    name: 'Networking',
     description:
       'At the core of iroh is the ability to connect to any online node with only a Peer identifier',
   },


### PR DESCRIPTION
This also tweaks the docs landing page to make the "networking" vs
"connections" terminology more consitent.