### PR TITLE
fix mismatch with cli commands.

### DIFF
--- a/src/app/docs/quickstart/page.mdx
+++ b/src/app/docs/quickstart/page.mdx
@@ -59,7 +59,7 @@ Next, let's create a document. Again we'll use the `--switch` the flag to use th
 
 <CodeGroup tag="CONSOLE">
 ```text
-> docs new --switch
+> docs create --switch
 x5qffedimrovdpsr3andm3hdjo6g2nlaqstdm6oe3utblxsdh3eq
 Active doc is now x5qffedimrovdpsr
 
@@ -77,7 +77,7 @@ author:fhu3uk4wc2hl2e45 doc:x5qffedimrovdpsr
 6lujp3wx2idm3bk5iqkzr6ssdk6hlkuwsu7jpqbqzfqsymgbfe6q
 
 author:fhu3uk4wc2hl2e45 doc:x5qffedimrovdpsr
-> doc get foo
+> docs get foo
 @fhu3uk4wc2hl2e45: foo = "bar" (3 B)
 ```
 </CodeGroup>
@@ -131,7 +131,7 @@ Now we can join the document from `Node B`, pasting in the value of the ticket w
 
 <CodeGroup tag="CONSOLE" title="Node B">
 ```text
-> authors new --switch
+> authors create --switch
 ksdx5fs4kwjmoaca2bod3z62vsm7ny42vubfxpczyr34trjvxp6q
 Active author is now ksdx5fs4kwjmoaca
 


### PR DESCRIPTION
While reviewing your documentation and working with Iroh,
I noticed a few minor discrepancies between the documentation and the actual CLI commands. 
These differences are likely due to changes introduced in this https://github.com/n0-computer/iroh/pull/2522 PR.