### PR TITLE
Fix open graph tags & footer design

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -13,12 +13,12 @@ export const metadata = {
   },
   openGraph: {
     title: 'iroh',
-    description: 'A distributed systems toolkit',
+    description: 'less net work for networks',
     images: [{
-      url: '/api/og?title=iroh&subtitle=A distributed systems toolkit',
+      url: '/api/og?title=iroh&subtitle=less net work for networks',
       width: 1200,
       height: 630,
-      alt: 'iroh. A distributed systems toolkit',
+      alt: 'iroh. less net work for networks',
       type: 'image/png',
     }],
     type: 'website'

--- a/src/app/page.mdx
+++ b/src/app/page.mdx
@@ -28,7 +28,7 @@ import iconPlatforms from '@/images/icons/icon_platforms.svg';
 export const metadata = {
   title: 'Iroh',
   description:
-    'Sync Anywhere',
+    'less net work for networks',
 };
 
 <HeaderSparse />
@@ -296,7 +296,7 @@ let value = try! doc.getContentBytes(hash: hash)
         </div>
       </div>
     </section>
-    <section className='max-w-6xl mx-auto px-10 border-r border-l border-t border-irohGray-300 dark:border-irohGray-800 py-20'>
+    <section className='max-w-6xl w-full mx-auto px-10 border-r border-l border-t border-irohGray-300 dark:border-irohGray-800 py-20'>
       <div className='w-full md:px-5'>
         <h3 className='text-lg tracking-wider font-bold text-irohGray-600 dark:text-irohGray-400 uppercase'>From the Blog</h3>
       </div>


### PR DESCRIPTION
Open graph tags said "A distributed systems toolkit" before, now it says "less net work for networks":
![image](https://github.com/user-attachments/assets/b2865d06-d603-46da-9b3f-1978bf516d99)

Also fixes a design issue with the footer.
Before:
![image](https://github.com/user-attachments/assets/096f92b2-5f9d-4aed-b53f-df20e7de7e9c)
After:
![image](https://github.com/user-attachments/assets/37a0a7e7-bd4f-44fb-8b0d-5ed88926ddbe)
