### PR TITLE
feat: Add and use `in-prose` utility

### DIFF
--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -20,7 +20,7 @@ export const sections = [
 Iroh lets you establish direct peer-to-peer connections whenever possible, falling back to relay servers if necessary.
 This gives you fast, reliable connections that are authenticated and encrypted end-to-end using QUIC. {{className: 'lead'}}
 
-<div className="not-prose">
+<div className="not-prose in-prose">
   <div className="mb-16 mt-6 flex gap-3">
     <Button href="/docs/quickstart" arrow="right" children="Quickstart" />
     <Button href="/docs/install" variant="outline" children="Install" />
@@ -31,7 +31,7 @@ This gives you fast, reliable connections that are authenticated and encrypted e
 
 The best place to start is by reading the overview, a high level look at the problems iroh solves by looking at component pieces. {{className: 'lead'}}
 
-<div className="not-prose">
+<div className="not-prose in-prose">
   <Button
     href="/overview"
     variant="text"

--- a/src/app/docs/protocols/blobs/page.mdx
+++ b/src/app/docs/protocols/blobs/page.mdx
@@ -13,7 +13,7 @@ A blob is a sequence of bytes. Those bytes can be a JPEG image, a text file, a v
 
 All blobs within iroh-blobs are referred to by the BLAKE3 [1] hash of its content. BLAKE3 is a _tree hashing_ algorithm, that splits its input into uniform chunks and arranges them as the leaves of a binary tree, producing intermediate _chunk hashes_ that accumulate up to a _root hash._ Iroh uses the 32 byte root hash (or just “hash”) as an immutable blob identifier. 
 
-<div className='not-prose mb-5'>
+<div className='not-prose in-prose mb-5'>
   <ThemeImage
     lightSrc='/diagrams/blobs_fig_1_blob.svg'
     darkSrc='/diagrams/blobs_fig_1_blob_dark.svg'
@@ -35,7 +35,7 @@ A _collection_ is an ordered set of blob hashes. {{ className: 'lead' }}
 
 Iroh-blobs uses collections as immutable, ordered lists of blobs. Collections themselves are blobs, serialized as a _hash sequence_ of one hash after another, with no separators or headers. Because all hashes in iroh-blobs are 32-byte BLAKE3 hashes, the byte length of a collection will always be a multiple of 32.
 
-<div className='not-prose mb-5'>
+<div className='not-prose in-prose mb-5'>
   <ThemeImage
     lightSrc='/diagrams/blobs_fig_2_collection.svg'
     darkSrc='/diagrams/blobs_fig_2_collection_dark.svg'

--- a/src/app/docs/protocols/docs/page.mdx
+++ b/src/app/docs/protocols/docs/page.mdx
@@ -4,7 +4,7 @@ import {ThemeImage} from '@/components/ThemeImage'
 
 A protocol for a mutable key-value store. Authors create and join documents, multiple users read from them, write to them, and sync with them, subscribing to live updates in real time. {{className: 'lead'}}
 
-<div className='not-prose mb-5'>
+<div className='not-prose in-prose mb-5'>
   <ThemeImage
     lightSrc='/diagrams/documents.svg'
     darkSrc='/diagrams/documents_dark.svg'

--- a/src/app/docs/protocols/gossip/page.mdx
+++ b/src/app/docs/protocols/gossip/page.mdx
@@ -12,7 +12,7 @@ export const metadata = {
 
 Gossip broadcasts messages to a network of live devices.{{ className: 'lead' }}
 
-<div className='not-prose mb-5'>
+<div className='not-prose in-prose mb-5'>
   <ThemeImage
     lightSrc='/diagrams/gossip_swarm_light.svg'
     darkSrc='/diagrams/gossip_swarm_dark.svg'

--- a/src/app/docs/quickstart/page.mdx
+++ b/src/app/docs/quickstart/page.mdx
@@ -45,25 +45,25 @@ Depending on how big this file is, `sendme` will first "injest" this file:
 $ sendme send ~/Downloads/Win11.iso
 ⠁ [00:00:00] [1/2] Ingesting 1 files, 6.33 GiB
 
-[2/2] /home/user/Downloads/Win11.iso⠲ [00:00:02] [########>------------------------] 1.37 GiB/6.33 GiB
+[2/2] /home/user/Downloads/Win11.iso⠲ [00:00:02] [#######>---------------------] 1.37 GiB/6.33 GiB
 ```
 
 And finally print a so-called "ticket" together with a command to run on another machine allowing you to retrieve this file there:
 
 ```
-imported file /home/user/Downloads/Win11.iso, 6.33 GiB, hash 4022bfc57b48dad832425808e4075554757214327b82fbf29a58923ad6cef86f
+imported file /home/user/Downloads/Win11.iso, 6.33 GiB, hash 4022bfc57b48dad[...]
 to get this data, use
-sendme receive blobabp7qggx4vk<...>
+sendme receive blobabp7qggx4vk[...]
 ```
 
 Now, possibly on any other machine, try receiving this file by copying the command that was printed above (with the whole ticket).
 Make sure to keep the previous command running.
 
 ```
-$ sendme receive blobabp7qggx4vk<...>
-getting collection 4022bfc57b48dad832425808e4075554757214327b82fbf29a58923ad6cef86f 1 files, 6.33 GiB
+$ sendme receive blobabp7qggx4vk[...]
+getting collection 4022bfc57b48dad[...] 1 files, 6.33 GiB
 [3/3] Downloading 3 blob(s)
-⠒ [00:00:05] [###>---------------------------------------------------] 387.48 MiB/6.33 GiB 74.70 MiB/s
+⠒ [00:00:05] [###>-----------------------------------------------] 387.48 MiB/6.33 GiB 74.70 MiB/s
 ```
 
 Once this command finishes, your file will be present in your current directory.

--- a/src/components/Code.jsx
+++ b/src/components/Code.jsx
@@ -267,7 +267,7 @@ export function CodeGroup({children, title, ...props}) {
     <CodeGroupContext.Provider value={true}>
       <Container
         {...containerProps}
-        className="not-prose my-6 overflow-hidden rounded-2xl bg-zinc-900 shadow-md dark:ring-1 dark:ring-white/10"
+        className="not-prose in-prose my-6 overflow-hidden rounded-2xl bg-zinc-900 shadow-md dark:ring-1 dark:ring-white/10"
       >
         <CodeGroupHeader title={title} {...headerProps}>
           {children}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -18,6 +18,14 @@
   }
 }
 
+@layer utilities {
+  .in-prose {
+    max-width: 50rem;
+    margin-left: calc(50% - min(50%, 33rem));
+    margin-right: calc(50% - min(50%, 33rem));
+  }
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This fixes the annoying layout on wide screens.

---

<h3 align="center">Before</h3>

![image](https://github.com/user-attachments/assets/5a745bbc-9800-4ec5-81fe-6dfd5f0b7505)

<h3 align="center">After</h3>

![image](https://github.com/user-attachments/assets/60766393-97de-4243-8dea-f4b52ad0773a)

---

<h3 align="center">Before</h3>

![image](https://github.com/user-attachments/assets/e977a386-37db-4b20-ba61-807ec7fe2272)

<h3 align="center">After</h3>

![image](https://github.com/user-attachments/assets/92406d64-0b7c-41ca-a361-aad9ec7a9416)

