### PR TITLE
Attempt to build a static RSS feed

### DIFF
--- a/src/app/rss/route.js
+++ b/src/app/rss/route.js
@@ -1,7 +1,8 @@
-import fs from "fs";
 import RSS from "rss";
 
 import { getAllPosts } from "@/lib/blog";
+
+export const dynamic  = 'force-static';
 
 export async function GET() {
   const allPosts = await getAllPosts();


### PR DESCRIPTION
I've noticed in production that the `/rss` page rendered a RSS feed without any posts, not allowing readers to fetch any updates about the project.

In development mode using `npm start dev`, the `localhost:3000/rss` page rendered all blog posts items, which is odd.

With `npm run build`, I've noticed that the `/rss` page was marked as a `dynamic function` route. Given that RSS feeds are built with the website, it's quite possible to also make it render statically similar to other blog posts.

After many different attempts of using the NexJS 15 API, I've found out that adding the `dynamic` metadata to the route made it statically generated during build.

Given I was not able to validate the issue locally, this is an attempt to fix the empty `/rss` feed by:

- Marking the page as statically generated
- Moving from `posts.map` to `post.forEach` to avoid lazy list evaluation not adding items to the `rss` object