### PR TITLE
Fix link to proto registry in /docs

### DIFF
--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -37,7 +37,7 @@ The best place to start is by reading the overview, a high level look at the pro
 
 <Resources>
   <Resource
-    href='/app/proto'
+    href='/proto'
     name='Protocol Registry'
     description='Iroh Protocols are pluggable extensions that build on direct connections.'
     icon='ArchiveBoxIcon'


### PR DESCRIPTION
Just fixing the "Protocol Registry" link on [this page](https://www.iroh.computer/docs).