### PR TITLE
fix(tour): correct Discovery page title in the Relays page

### DIFF
--- a/src/app/docs/tour/2-relays/page.mdx
+++ b/src/app/docs/tour/2-relays/page.mdx
@@ -38,6 +38,6 @@ It also leverages a critical feature of iroh: as network conditions change, iroh
     <PageLink label="Previous" page={{ href: "/docs/tour/1-endpoints", title: "Endpoints" }} previous />
   </div>
   <div className="ml-auto flex flex-col items-end gap-3">
-    <PageLink label="Next" page={{ href: "/docs/tour/3-discovery", title: "Relays" }} />
+    <PageLink label="Next" page={{ href: "/docs/tour/3-discovery", title: "Discovery" }} />
   </div>
 </div>


### PR DESCRIPTION
The title was incorrectly set to "Relays" instead of "Discovery".