### PR TITLE
Add Windows support to `sendme.sh`

### DIFF
--- a/public/sendme.sh
+++ b/public/sendme.sh
@@ -32,7 +32,7 @@ if [[ "$release_target_url" =~ \.zip$ ]]; then
         curl -s "$release_url" |
         grep "name" |
         grep "$target" |
-        sed -re 's/.*: "([^"]+)".*/\1/'
+        sed -re 's/.*: "([^"]+)".*/\1/' \
     )
     curl -sL "$release_target_url" -o $release_archive
     unzip -oq $release_archive


### PR DESCRIPTION
This support is for users who have access to a terminal which supports running shell scripts on Windows. Tested and functional.

View https://github.com/n0-computer/sendme/issues/86 for past comments regarding this update.