### PR TITLE
remove tldr note

### DIFF
--- a/src/app/docs/concepts/tickets/page.mdx
+++ b/src/app/docs/concepts/tickets/page.mdx
@@ -1,6 +1,6 @@
 # Tickets
 
-**Tl;DR:** Tickets are a way to share dialing information between iroh nodes. They're a single token that contains everything needed to connect to another node, or to fetch a blob or document. {{className: 'lead'}}
+Tickets are a way to share dialing information between iroh nodes. They're a single token that contains everything needed to connect to another node, or to fetch a blob or document. {{className: 'lead'}}
 
 <Note>
 Have a ticket? Try pasting it into the [iroh ticket explorer](https://ticket.iroh.computer) to break it down! Here's an [example](https://ticket.iroh.computer?ticket=docaaacarwhmusoqf362j3jpzrehzkw3bqamcp2mmbhn3fmag3mzzfjp4beahj2v7aezhojvfqi5wltr4vxymgzqnctryyup327ct7iy4s5noxy6aaa)


### PR DESCRIPTION
The other tldr subtitles within Concepts don't have such a note.