### PR TITLE
fix heading level

### DIFF
--- a/src/app/docs/concepts/router/page.mdx
+++ b/src/app/docs/concepts/router/page.mdx
@@ -1,5 +1,4 @@
-
-## Router
+# Router
 
 To make composing protocols easier, iroh includes a _router_ for composing together multiple protocols. {{className: 'lead'}}
 


### PR DESCRIPTION
The other first headings in the Concepts section are `h1`s.