### PR TITLE
docs: Add more protocols

### DIFF
--- a/src/app/proto/protocols.js
+++ b/src/app/proto/protocols.js
@@ -46,5 +46,23 @@ export const protocols = [
     "documentation": "https://godotengine.org/asset-library/asset/3948",
     "repository": "https://github.com/tipragot/godot-iroh",
     "version": "v0.1.5"
+  },
+  {
+    "icon": "",
+    "title": " Iroh Content Discovery",
+    "tagline": "A protocol to communicate with a content tracker for iroh-blobs.",
+    "slug": "iroh-content-discovery",
+    "documentation": "https://docs.rs/iroh-content-discovery/latest/iroh_content_discovery/",
+    "repository": "https://github.com/tipragot/godot-iroh",
+    "version": "v0.1.0"
+  },
+  {
+    "icon": "",
+    "title": "Iroh ping",
+    "tagline": "A minimal protocol to ping iroh nodes.",
+    "slug": "iroh-ping",
+    "documentation": "https://docs.rs/iroh-ping/latest/iroh_ping/",
+    "repository": "https://github.com/n0-computer/iroh-ping",
+    "version": "v0.2.0"
   }
 ]


### PR DESCRIPTION
This PR only adds protocols that are already usable and have at least a published crate.

I will do another one that adds repos that are not yet published on crates.io.