### PR TITLE
Add more experimental protocols

### DIFF
--- a/src/app/proto/protocols.js
+++ b/src/app/proto/protocols.js
@@ -54,7 +54,8 @@ export const protocols = [
     "slug": "iroh-content-discovery",
     "documentation": "https://docs.rs/iroh-content-discovery/latest/iroh_content_discovery/",
     "repository": "https://github.com/tipragot/godot-iroh",
-    "version": "v0.1.0"
+    "version": "v0.1.0",
+    experimental: true,
   },
   {
     "icon": "",
@@ -64,5 +65,65 @@ export const protocols = [
     "documentation": "https://docs.rs/iroh-ping/latest/iroh_ping/",
     "repository": "https://github.com/n0-computer/iroh-ping",
     "version": "v0.2.0"
+  },
+  {
+    "icon": "",
+    "title": "Iroh protocol for Rateless IBLTs",
+    "tagline": "Set reconciliation with RIBLTs, as an iroh protocol",
+    "slug": "iroh-riblt",
+    "documentation": "https://github.com/b5/iroh-riblt",
+    "repository": "https://github.com/b5/iroh-riblt",
+    "version": "v0.1.0 (unpublished)",
+    experimental: true,
+  },
+
+  {
+    "icon": "",
+    "title": "Iroh protocol for range-based set reconciliation",
+    "tagline": "Range-based set reconciliation as an iroh protocol",
+    "slug": "iroh-ranger",
+    "documentation": "https://github.com/b5/iroh-ranger",
+    "repository": "https://github.com/b5/iroh-ranger",
+    "version": "v0.1.0 (unpublished)",
+    experimental: true,
+  },
+  {
+    "icon": "",
+    "title": "Using iroh as a dumb pipe",
+    "tagline": "Just a dumb pipe",
+    "slug": "dumbpipe",
+    "documentation": "https://docs.rs/dumbpipe/latest/dumbpipe/",
+    "repository": "https://github.com/n0-computer/dumbpipe",
+    "version": "v0.28.0"
+  },
+  {
+    "icon": "",
+    "title": "Frosty threshold signatures",
+    "tagline": "A protocol for threshold signatures using the frost scheme.",
+    "slug": "frosty",
+    "documentation": "https://github.com/n0-computer/iroh-examples/tree/main/frosty",
+    "repository": "https://github.com/n0-computer/iroh-examples/tree/main/frosty",
+    "version": "v0.1.0 (unpublished)",
+    experimental: true,
+  },
+  {
+    "icon": "",
+    "title": "Frosty threshold signatures",
+    "tagline": "A protocol for threshold signatures using the frost scheme.",
+    "slug": "Iroh automerge",
+    "documentation": "https://github.com/n0-computer/iroh-examples/tree/main/iroh-automerge",
+    "repository": "https://github.com/n0-computer/iroh-examples/tree/main/iroh-automerge",
+    "version": "v0.1.0 (unpublished)",
+    experimental: true,
+  },
+  {
+    "icon": "",
+    "title": "Beelay/Keyhive Iroh Protocol",
+    "tagline": "Custom Iroh Protocol for integrating Beelay/Keyhive",
+    "slug": "iroh-beelay",
+    "documentation": "https://github.com/symplasma/custom_beelay_iroh_protocol",
+    "repository": "https://github.com/symplasma/custom_beelay_iroh_protocol",
+    "version": "v0.1.0 (unpublished)",
+    experimental: true,
   }
 ]

--- a/src/app/proto/protocols.js
+++ b/src/app/proto/protocols.js
@@ -46,5 +46,23 @@ export const protocols = [
     "documentation": "https://godotengine.org/asset-library/asset/3948",
     "repository": "https://github.com/tipragot/godot-iroh",
     "version": "v0.1.5"
+  },
+  {
+    "icon": "",
+    "title": " Iroh Content Discovery",
+    "tagline": "A protocol to communicate with a content tracker for iroh-blobs.",
+    "slug": "iroh-content-discovery",
+    "documentation": "https://docs.rs/iroh-content-discovery/latest/iroh_content_discovery/",
+    "repository": "https://github.com/tipragot/godot-iroh",
+    "version": "v0.1.0"
+  },
+  {
+    "icon": "",
+    "title": "Iroh ping",
+    "tagline": "A minimal protocol to ping iroh nodes.",
+    "slug": "iroh-ping",
+    "documentation": "https://docs.rs/iroh-ping/latest/iroh_ping/",
+    "repository": "https://github.com/n0-computer/iroh-ping",
+    "version": "v0.2.0"
   }
 ]


### PR DESCRIPTION
Note: the docs link does not work if the repo is not at top level,

e.g. https://github.com/n0-computer/iroh-examples/tree/main/iroh-automerge:

<img width="1032" height="658" alt="image" src="https://github.com/user-attachments/assets/ab071f07-e496-487b-ad4f-c2e0037ea7a7" />

If we could fix that it would be nice to add the experimental protocols, maybe in a different section. This would be not for people to just grab and use, but as a starting point / inspiration.