### PR TITLE
fix: Roadmap expected 1.0 release "H3 2025" -> "H2 2025"

### DIFF
--- a/src/app/roadmap/roadmap.json
+++ b/src/app/roadmap/roadmap.json
@@ -250,7 +250,7 @@
       "tracking_issue": "",
       "doc": ""
     },
-    { "version": "v1.0", "done": false, "released": "", "link": "", "expected": "H3 2025" },
+    { "version": "v1.0", "done": false, "released": "", "link": "", "expected": "H2 2025" },
     { "all_done": false, "title": "Party", "description": "That's it. All done. no more work left to do, ever. :)", "link": "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
   ]
 }

--- a/src/app/roadmap/roadmap.json
+++ b/src/app/roadmap/roadmap.json
@@ -174,7 +174,7 @@
       "description": "transition from anyhow to thiserror in all critical code paths",
       "tracking_issue": "https://github.com/n0-computer/iroh/issues/2741"
     },
-    { "version": "v0.90.0", "done": true, "released": "2025-05-12", "doc": "https://www.iroh.computer/blog/iroh-0-90-the-canary-series" },
+    { "version": "v0.90.0", "done": true, "released": "2025-06-27", "doc": "https://www.iroh.computer/blog/iroh-0-90-the-canary-series" },
     {
       "done": false,
       "title": "blobs 1.0 API",


### PR DESCRIPTION
Fixing it this way, [briefly checked that with others](https://www.notion.so/Don-t-say-1-0-comes-in-Half-3-2025-on-iroh-computer-roadmap-2345df1306fb8049a813d9ef525a158f?d=2365df1306fb8050a1d7001c1ec42cf6&source=copy_link#2345df1306fb80ae96bbe4856377c149)