### PR TITLE
blog: rename error handling blog post

### DIFF
--- a/src/app/blog/error-handling-in-iroh/page.mdx
+++ b/src/app/blog/error-handling-in-iroh/page.mdx
@@ -5,7 +5,7 @@ export const post = {
   draft: false,
   author: 'dig, b5, ramfox',
   date: '2025-08-22',
-  title: 'Error backtraces in rust libraries: an adventure',
+  title: 'Trying to get error backtraces in rust libraries right',
   description: "Read about iroh's approach to error handling",
 }
 


### PR DESCRIPTION
This changes the title, but keeps the url the same so no past links will be broken.