### PR TITLE
feat: past-releases in roadmap

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import clsx from 'clsx';
 import { CheckCircleIcon, EllipsisHorizontalIcon, TrophyIcon } from '@heroicons/react/20/solid';
@@ -5,13 +7,14 @@ import { CheckCircleIcon, EllipsisHorizontalIcon, TrophyIcon } from '@heroicons/
 import roadmap from './roadmap.json';
 import { BlankLayout } from '@/components/BlankLayout';
 import { formatDate } from '@/lib/formatDate'
+import { useState } from 'react';
+import { ArrowDown, ArrowRight, ChevronDown, ChevronRight } from 'lucide-react';
 
-export const metadata = {
-  title: 'Roadmap',
-  description:
-    'Iroh 1.0 roadmap. Here\'s where we\'re headed, and progress we made against our goal to date.',
-};
-
+// export const metadata = {
+//   title: 'Roadmap',
+//   description:
+//     'Iroh 1.0 roadmap. Here\'s where we\'re headed, and progress we made against our goal to date.',
+// };
 
 export default function Component() {
   const { last_updated } = roadmap;
@@ -26,17 +29,47 @@ export default function Component() {
           <h1 className='text-3xl font-bold font-space-mono text-iroh-gray-700 mb-4'></h1>
           <p className='text-iroh-gray-500'></p>
         </div>
-        {roadmap.milestones.map((milestone, i) => {
-          if (milestone.version) {
-            return <Release key={i} data={milestone} />
-          } else if (milestone.all_done === false || milestone.all_done === true) {
-            return <AllDone key={i} data={milestone} />
-          } else if (milestone.ellipsis) {
-            return <Ellipsis key={i} data={milestone} />
-          }
-          return <Milestone key={i} data={milestone} />
-        })}
+        <Milestones data={roadmap.milestones} />
     </BlankLayout>
+  )
+}
+
+function Milestones({ data }) {
+  return data.map((milestone, i) => {
+      if (milestone.section) {
+        return <Section key={i} data={milestone} />
+      } else if (milestone.version) {
+        return <Release key={i} data={milestone} />
+      } else if (milestone.all_done === false || milestone.all_done === true) {
+        return <AllDone key={i} data={milestone} />
+      } else if (milestone.ellipsis) {
+        return <Ellipsis key={i} data={milestone} />
+      }
+      return <Milestone key={i} data={milestone} />
+    })
+}
+
+function Section({ data }) {
+  const { section, startCollapsed, milestones } = data;
+  const [collapsed, setCollapsed] = useState(startCollapsed);
+  const first_release_string = formatDate(milestones.find((m) => m.released).released, true)
+  const last_release_string = formatDate(milestones.findLast((m) => m.released).released, true)
+
+  return (
+    <div>
+      <div style={{ marginLeft: '6.5rem' }} className='pr-5 relative flex gap-4 w-full'>
+        <button className='cursor-pointer border-1 border-iroh-purple-400 p-3 w-12 h-12 rounded-full' onClick={() => setCollapsed(!collapsed)}>
+          {collapsed? <ChevronRight /> : <ChevronDown /> }
+        </button>
+        <button className='text-left cursor-pointer' onClick={() => setCollapsed(!collapsed)}>
+          <h3 className='w-full text-xl leading-6 text-iroh-gray-600 font-space font-bold dark:text-iroh-gray-400'>{section}</h3>
+          <p className='text-xs text-iroh-gray-400 dark:text-iroh-gray-600'>
+            {milestones.filter((m) => m.version).length} releases: {first_release_string} - {last_release_string}
+          </p>
+        </button>
+      </div>
+      {!collapsed && <Milestones data={milestones} />}
+    </div>
   )
 }
 
@@ -62,6 +95,7 @@ function Release({ data }) {
     </div>
   )
 }
+
 
 function Milestone({ data }) {
   const { done, title, description, subtasks, tracking_issue, doc } = data;

--- a/src/app/roadmap/roadmap.json
+++ b/src/app/roadmap/roadmap.json
@@ -1,236 +1,241 @@
 {
-  "last_updated": "2025-10-20",
+  "last_updated": "2025-10-23",
   "milestones": [
-    {
-      "done": true,
-      "title": "docs are disabled by default",
-      "description": "transition node builder away from assuming all users want the docs protocol",
-      "tracking_issue": "https://github.com/n0-computer/iroh/pull/2748"
-    },
-    { "version": "v0.26.0", "done": true, "released": "2024-09-30", "doc": "https://www.iroh.computer/blog/iroh-0-26-0-Say-Hello-to-Your-Neighbors" },
-    { "version": "v0.27.0", "done": true, "released": "2024-10-21", "doc": "https://www.iroh.computer/blog/iroh-0-27-0-Squashing-Bugs-And-Taking-Names" },
-    {
-      "done": true,
-      "title": "pull custom protocols out of iroh",
-      "description": "pull custom protocols out of iroh and into separate repositories",
-      "tracking_issue": null,
-      "subtasks": {
-        "iroh-blobs": true,
-        "iroh-docs": true,
-        "iroh-gossip": true
-      }
-    },
-    {
-      "done": true,
-      "title": "blobs, docs, and gossip are disabled by default",
-      "description": "protocols remain in the codebase but must be explicitly enabled",
-      "tracking_issue": null
-    },
-    {
-      "done": true,
-      "title": "Implement QUIC Address Discovery",
-      "description": "Add QUIC Address Discovery functionality to `iroh-quinn`",
-      "tracking_issue": "https://github.com/n0-computer/quinn/pull/12"
-    },
-    {
-      "done": true,
-      "title": "Iroh CLI Deprecation Warning",
-      "description": "warn users that the iroh CLI is deprecated and will be converted to an example in the next release",
-      "tracking_issue": null
-    },
-    {
-      "done": true,
-      "title": "Iroh client Deprecation Warning",
-      "description": "warn users that the iroh client is deprecated and will be converted to an example in the next release",
-      "tracking_issue": null
-    },
-    { "version": "v0.28.1", "done": true, "released": "2024-11-04", "doc": "https://iroh.computer/blog/iroh-0-28-let-them-have-crates" },
-    {
-      "done": true,
-      "title": "net-tools repo",
-      "description": "factor a number of networking tools out of iroh and into a separate repo",
-      "doc": "",
-      "subtasks": {
-        "netcheck": true,
-        "portmapper": true
-      }
-    },
-    {
-      "done": true,
-      "title": "Add QUIC Address Discovery to iroh-relay",
-      "description": "serve QUIC Address Discovery on the relay",
-      "tracking_issue": "https://github.com/n0-computer/iroh/issues/2842"
-    },
-    {
-      "done": true,
-      "title": "blobs, docs, and gossip are removed from iroh",
-      "description": "protocols exist in their own repos and are published separately from iroh",
-      "tracking_issue": null
-    },
-    {
-      "done": true,
-      "title": "CLI is removed from iroh",
-      "description": "there is no more CLI or Node in iroh, look at the specific protocols to play with a CLI centered around that protocol",
-      "tracking_issue": null
-    },
-    {
-      "done": true,
-      "title": "iroh-net is now just iroh",
-      "description": "we no longer publish `iroh-net`, `iroh` contains all of `iroh-net`",
-      "tracking_issue": null
-    },
-    { "version": "v0.29.0", "done": true, "released": "2024-12-02", "doc": "https://www.iroh.computer/blog/iroh-0-29-net-is-the-new-iroh" },
-    {
-      "done": true,
-      "title": "Add QUIC Address Discovery to `iroh-net-report`",
-      "description": "net-report has QUIC Address Discovery probes",
-      "tracking_issue": "https://github.com/n0-computer/iroh/issues/2842"
-    },
-    { "version": "v0.30.0", "done": true, "released": "2024-12-16", "doc": "https://www.iroh.computer/blog/iroh-0-30-0-slimming-down" },
-    {
-      "done": true,
-      "title": "Auth on Relays",
-      "description": "Blacklist or whitelist `NodeId`s on the relay",
-      "tracking_issue": "https://github.com/n0-computer/iroh/pull/3086"
-    },
-    {
-      "done": true,
-      "title": "Iroh Doctor CLI v0.1",
-      "description": "release the first version of the iroh doctor CLI as a standalone tool for diagnosing and reporting on connectivity",
-      "tracking_issue": null
-    },
-    { "version": "v0.31.0", "done": true, "released": "2025-01-14", "doc": "https://www.iroh.computer/blog/iroh-0-31-0-back-to-fighting-fit" },
-    {
-      "done": true,
-      "title": "Add QUIC Address Discovery to `iroh`",
-      "description": "iroh can launch QUIC Address Discovery probes",
-      "tracking_issue": "https://github.com/n0-computer/iroh/pull/3049"
-    },
-    { "version": "v0.32.0", "done": true, "released": "2025-02-03", "doc": "https://www.iroh.computer/blog/iroh-0-32-0-browser-alpha-qad-and-n0-future" },
-    {
-      "done": true,
-      "title": "browser support",
-      "description": "iroh compiles to web assembly and runs in the browser",
-      "tracking_issue": "https://github.com/n0-computer/iroh/issues/2799",
-      "doc": "https://www.iroh.computer/blog/iroh-and-the-web"
-    },
-    {
-      "done": true,
-      "title": "User-defined data in Discovery",
-      "description": "Allow users to publish and resolve a user-defined data.",
-      "tracing_issue": "https://github.com/n0-computer/iroh/pull/3176"
-    },
-    {
-      "done": true,
-      "title": "Discovery stream subscription",
-      "description": "Add simple API to allow users to subscribe to a stream of discoveries.",
-      "tracing_issue": "https://github.com/n0-computer/iroh/pull/3181"
-    },
-    {
-      "done": true,
-      "title": "QUIC connections: graceful shutdown",
-      "description": "finalize our APIs for graceful shutdown of QUIC connections",
-      "tracking_issue": "https://github.com/n0-computer/iroh/pull/3170"
-    },
-    {
-      "done": true,
-      "title": "0-RTT",
-      "description": "iroh QUIC connections can now leverage 0-RTT",
-      "tracking_issue": "https://github.com/n0-computer/iroh/pull/3163"
-    },
-    { "version": "v0.33.0", "done": true, "released": "2025-02-24", "doc": "https://iroh.computer/blog/iroh-0-33-0-browsers-and-discovery-and-0-RTT-oh-my" },
-    {
-      "done": true,
-      "title": "use Raw Public Keys (RFC 7250) in TLS",
-      "description": "use Raw Public Keys instead of self-signed certificates in TLS",
-      "tracking_issue": "https://github.com/n0-computer/iroh/issues/2798",
-      "doc": "https://datatracker.ietf.org/doc/html/rfc7250"
-    },
-    {
-      "done": true,
-      "title": "improved tags API for `iroh-blobs`",
-      "description": "expand tags API",
-      "tracking_issue": null
-    },
-    { "version": "v0.34.1", "done": true, "released": "2025-03-18", "doc": "https://www.iroh.computer/blog/iroh-0-34-0-raw-public-keys" },
-    {
-      "done": true,
-      "title": "relay connections over websockets",
-      "description": "Connections to the relay happen over websockets",
-      "tracking_issue": null,
-      "doc": null
-    },
-    {
-      "done": true,
-      "title": "metrics are collected per-endpoint",
-      "description": "Previously, metrics were collected globably. Now, each `iroh` endpoint collects metrics for itself.",
-      "tracking_issue": null,
-      "doc": null
-    },
-    { "version": "v0.35.0", "done": true, "released": "2025-05-12", "doc": "https://www.iroh.computer/blog/iroh-0-35-prepping-for-1-0" },
-    {
-      "done": true,
-      "title": "Formalize Error Responses",
-      "description": "transition from anyhow to thiserror in all critical code paths",
-      "tracking_issue": "https://github.com/n0-computer/iroh/issues/2741"
-    },
-    {
-      "done": true,
-      "title": "iroh-blobs 1.0 candidate API",
-      "description": "Overhaul the blobs API",
-      "tracking_issue": null
-    },
-    {
-      "done": true,
-      "title": "iroh-blobs: multiprovider fan-in",
-      "description": "Download data from multiple providers using the `SplitStrategy` enum",
-      "tracking_issue": "https://github.com/n0-computer/iroh-blobs/issues/4",
-      "doc": "https://docs.rs/iroh-blobs/latest/iroh_blobs/api/downloader/enum.SplitStrategy.html"
-    },
-    { "version": "v0.90.0", "done": true, "released": "2025-06-27", "doc": "https://www.iroh.computer/blog/iroh-0-90-the-canary-series" },
-    {
-      "done": true,
-      "title": "deprecate TCP relay connections",
-      "description": "We no longer support connecting to the relays using raw TCP, only WebSockets",
-      "tracking_issue": null,
-      "doc": null
-    },
-    {
-      "done": true,
-      "title": "Overhaul the relay protocol",
-      "description": "Fix the relay handshake, clean up unused frames.",
-      "tracking_issue": null,
-      "doc": null
-    },
-    { "version": "v0.91.0", "done": true, "released": "2025-07-30", "doc": "https://www.iroh.computer/blog/iroh-0-91-0-the-last-relay-break" },
-    {
-      "done": true,
-      "title": "mDNS passive mode",
-      "description": "Allow discovering local nodes without advertising your own.",
-      "tracking_issue": null,
-      "doc": null
-    },
-    {
-      "done": true,
-      "title": "mDNS Expiry Events",
-      "description": "Emit expiry events in the `subscribe` stream.",
-      "tracking_issue": null,
-      "doc": null
-    },
-    { "version": "v0.92.0", "done": true, "released": "2025-09-18", "doc": "https://www.iroh.computer/blog/iroh-0-92-mdns-improvements" },
-    {
-      "done": true,
-      "title": "`Endpoint::online`",
-      "description": "Add method for determining if your endpoint is \"online\".",
-      "tracking_issue": null,
-      "doc": null
-    },
-    {
-      "done": true,
-      "title": "Dynamically add Discovery services",
-      "description": "Add discovery services to an already running endpoint",
-      "tracking_issue": null,
-      "doc": null
+    { "section" : "past releases",
+      "startCollapsed": true,
+      "milestones": [
+        {
+          "done": true,
+          "title": "docs are disabled by default",
+          "description": "transition node builder away from assuming all users want the docs protocol",
+          "tracking_issue": "https://github.com/n0-computer/iroh/pull/2748"
+        },
+        { "version": "v0.26.0", "done": true, "released": "2024-09-30", "doc": "https://www.iroh.computer/blog/iroh-0-26-0-Say-Hello-to-Your-Neighbors" },
+        { "version": "v0.27.0", "done": true, "released": "2024-10-21", "doc": "https://www.iroh.computer/blog/iroh-0-27-0-Squashing-Bugs-And-Taking-Names" },
+        {
+          "done": true,
+          "title": "pull custom protocols out of iroh",
+          "description": "pull custom protocols out of iroh and into separate repositories",
+          "tracking_issue": null,
+          "subtasks": {
+            "iroh-blobs": true,
+            "iroh-docs": true,
+            "iroh-gossip": true
+          }
+        },
+        {
+          "done": true,
+          "title": "blobs, docs, and gossip are disabled by default",
+          "description": "protocols remain in the codebase but must be explicitly enabled",
+          "tracking_issue": null
+        },
+        {
+          "done": true,
+          "title": "Implement QUIC Address Discovery",
+          "description": "Add QUIC Address Discovery functionality to `iroh-quinn`",
+          "tracking_issue": "https://github.com/n0-computer/quinn/pull/12"
+        },
+        {
+          "done": true,
+          "title": "Iroh CLI Deprecation Warning",
+          "description": "warn users that the iroh CLI is deprecated and will be converted to an example in the next release",
+          "tracking_issue": null
+        },
+        {
+          "done": true,
+          "title": "Iroh client Deprecation Warning",
+          "description": "warn users that the iroh client is deprecated and will be converted to an example in the next release",
+          "tracking_issue": null
+        },
+        { "version": "v0.28.1", "done": true, "released": "2024-11-04", "doc": "https://iroh.computer/blog/iroh-0-28-let-them-have-crates" },
+        {
+          "done": true,
+          "title": "net-tools repo",
+          "description": "factor a number of networking tools out of iroh and into a separate repo",
+          "doc": "",
+          "subtasks": {
+            "netcheck": true,
+            "portmapper": true
+          }
+        },
+        {
+          "done": true,
+          "title": "Add QUIC Address Discovery to iroh-relay",
+          "description": "serve QUIC Address Discovery on the relay",
+          "tracking_issue": "https://github.com/n0-computer/iroh/issues/2842"
+        },
+        {
+          "done": true,
+          "title": "blobs, docs, and gossip are removed from iroh",
+          "description": "protocols exist in their own repos and are published separately from iroh",
+          "tracking_issue": null
+        },
+        {
+          "done": true,
+          "title": "CLI is removed from iroh",
+          "description": "there is no more CLI or Node in iroh, look at the specific protocols to play with a CLI centered around that protocol",
+          "tracking_issue": null
+        },
+        {
+          "done": true,
+          "title": "iroh-net is now just iroh",
+          "description": "we no longer publish `iroh-net`, `iroh` contains all of `iroh-net`",
+          "tracking_issue": null
+        },
+        { "version": "v0.29.0", "done": true, "released": "2024-12-02", "doc": "https://www.iroh.computer/blog/iroh-0-29-net-is-the-new-iroh" },
+        {
+          "done": true,
+          "title": "Add QUIC Address Discovery to `iroh-net-report`",
+          "description": "net-report has QUIC Address Discovery probes",
+          "tracking_issue": "https://github.com/n0-computer/iroh/issues/2842"
+        },
+        { "version": "v0.30.0", "done": true, "released": "2024-12-16", "doc": "https://www.iroh.computer/blog/iroh-0-30-0-slimming-down" },
+        {
+          "done": true,
+          "title": "Auth on Relays",
+          "description": "Blacklist or whitelist `NodeId`s on the relay",
+          "tracking_issue": "https://github.com/n0-computer/iroh/pull/3086"
+        },
+        {
+          "done": true,
+          "title": "Iroh Doctor CLI v0.1",
+          "description": "release the first version of the iroh doctor CLI as a standalone tool for diagnosing and reporting on connectivity",
+          "tracking_issue": null
+        },
+        { "version": "v0.31.0", "done": true, "released": "2025-01-14", "doc": "https://www.iroh.computer/blog/iroh-0-31-0-back-to-fighting-fit" },
+        {
+          "done": true,
+          "title": "Add QUIC Address Discovery to `iroh`",
+          "description": "iroh can launch QUIC Address Discovery probes",
+          "tracking_issue": "https://github.com/n0-computer/iroh/pull/3049"
+        },
+        { "version": "v0.32.0", "done": true, "released": "2025-02-03", "doc": "https://www.iroh.computer/blog/iroh-0-32-0-browser-alpha-qad-and-n0-future" },
+        {
+          "done": true,
+          "title": "browser support",
+          "description": "iroh compiles to web assembly and runs in the browser",
+          "tracking_issue": "https://github.com/n0-computer/iroh/issues/2799",
+          "doc": "https://www.iroh.computer/blog/iroh-and-the-web"
+        },
+        {
+          "done": true,
+          "title": "User-defined data in Discovery",
+          "description": "Allow users to publish and resolve a user-defined data.",
+          "tracing_issue": "https://github.com/n0-computer/iroh/pull/3176"
+        },
+        {
+          "done": true,
+          "title": "Discovery stream subscription",
+          "description": "Add simple API to allow users to subscribe to a stream of discoveries.",
+          "tracing_issue": "https://github.com/n0-computer/iroh/pull/3181"
+        },
+        {
+          "done": true,
+          "title": "QUIC connections: graceful shutdown",
+          "description": "finalize our APIs for graceful shutdown of QUIC connections",
+          "tracking_issue": "https://github.com/n0-computer/iroh/pull/3170"
+        },
+        {
+          "done": true,
+          "title": "0-RTT",
+          "description": "iroh QUIC connections can now leverage 0-RTT",
+          "tracking_issue": "https://github.com/n0-computer/iroh/pull/3163"
+        },
+        { "version": "v0.33.0", "done": true, "released": "2025-02-24", "doc": "https://iroh.computer/blog/iroh-0-33-0-browsers-and-discovery-and-0-RTT-oh-my" },
+        {
+          "done": true,
+          "title": "use Raw Public Keys (RFC 7250) in TLS",
+          "description": "use Raw Public Keys instead of self-signed certificates in TLS",
+          "tracking_issue": "https://github.com/n0-computer/iroh/issues/2798",
+          "doc": "https://datatracker.ietf.org/doc/html/rfc7250"
+        },
+        {
+          "done": true,
+          "title": "improved tags API for `iroh-blobs`",
+          "description": "expand tags API",
+          "tracking_issue": null
+        },
+        { "version": "v0.34.1", "done": true, "released": "2025-03-18", "doc": "https://www.iroh.computer/blog/iroh-0-34-0-raw-public-keys" },
+        {
+          "done": true,
+          "title": "relay connections over websockets",
+          "description": "Connections to the relay happen over websockets",
+          "tracking_issue": null,
+          "doc": null
+        },
+        {
+          "done": true,
+          "title": "metrics are collected per-endpoint",
+          "description": "Previously, metrics were collected globably. Now, each `iroh` endpoint collects metrics for itself.",
+          "tracking_issue": null,
+          "doc": null
+        },
+        { "version": "v0.35.0", "done": true, "released": "2025-05-12", "doc": "https://www.iroh.computer/blog/iroh-0-35-prepping-for-1-0" },
+        {
+          "done": true,
+          "title": "Formalize Error Responses",
+          "description": "transition from anyhow to thiserror in all critical code paths",
+          "tracking_issue": "https://github.com/n0-computer/iroh/issues/2741"
+        },
+        {
+          "done": true,
+          "title": "iroh-blobs 1.0 candidate API",
+          "description": "Overhaul the blobs API",
+          "tracking_issue": null
+        },
+        {
+          "done": true,
+          "title": "iroh-blobs: multiprovider fan-in",
+          "description": "Download data from multiple providers using the `SplitStrategy` enum",
+          "tracking_issue": "https://github.com/n0-computer/iroh-blobs/issues/4",
+          "doc": "https://docs.rs/iroh-blobs/latest/iroh_blobs/api/downloader/enum.SplitStrategy.html"
+        },
+        { "version": "v0.90.0", "done": true, "released": "2025-06-27", "doc": "https://www.iroh.computer/blog/iroh-0-90-the-canary-series" },
+        {
+          "done": true,
+          "title": "deprecate TCP relay connections",
+          "description": "We no longer support connecting to the relays using raw TCP, only WebSockets",
+          "tracking_issue": null,
+          "doc": null
+        },
+        {
+          "done": true,
+          "title": "Overhaul the relay protocol",
+          "description": "Fix the relay handshake, clean up unused frames.",
+          "tracking_issue": null,
+          "doc": null
+        },
+        { "version": "v0.91.0", "done": true, "released": "2025-07-30", "doc": "https://www.iroh.computer/blog/iroh-0-91-0-the-last-relay-break" },
+        {
+          "done": true,
+          "title": "mDNS passive mode",
+          "description": "Allow discovering local nodes without advertising your own.",
+          "tracking_issue": null,
+          "doc": null
+        },
+        {
+          "done": true,
+          "title": "mDNS Expiry Events",
+          "description": "Emit expiry events in the `subscribe` stream.",
+          "tracking_issue": null,
+          "doc": null
+        },
+        { "version": "v0.92.0", "done": true, "released": "2025-09-18", "doc": "https://www.iroh.computer/blog/iroh-0-92-mdns-improvements" },
+        {
+          "done": true,
+          "title": "`Endpoint::online`",
+          "description": "Add method for determining if your endpoint is \"online\".",
+          "tracking_issue": null,
+          "doc": null
+        },
+        {
+          "done": true,
+          "title": "Dynamically add Discovery services",
+          "description": "Add discovery services to an already running endpoint",
+          "tracking_issue": null,
+          "doc": null
+        }
+      ]
     },
     { "version": "v0.93.0", "done": true, "released": "2025-10-08", "doc": "https://www.iroh.computer/blog/iroh-0-93-iroh-online" },
     {


### PR DESCRIPTION
This adds a "past releases" disclosure triangle that hides our (now long) release history so folks can jump to the end by default:

<img width="687" height="789" alt="Screenshot 2025-10-23 at 10 49 58 AM" src="https://github.com/user-attachments/assets/4e27cfa6-46b3-4b8d-875a-50353698e257" />
