### PR TITLE
Add authentication as a key feature of hosted relays

### DIFF
--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -23,7 +23,7 @@ const plans = [
     buttonLabel: 'Get Started',
     features: [
       'All features in Pro, limited',
-      '1 day retention',
+      '7 day retention',
       'Community support',
     ],
   },
@@ -37,7 +37,7 @@ const plans = [
     buttonLabel: 'Free trial',
     features: [
       'Pay as you go pricing',
-      '7 day retention',
+      '30 day retention',
       '8x5 support tickets',
     ],
   },
@@ -76,7 +76,7 @@ const featureSections = [
     name: 'Metrics',
     features: [
       { name: 'Data Points per Minute', free: '1K DPM', freeNote: '100 metrics \u00d7 10 endpoints', pro: '10K DPM', proNote: 'then $1.49/1K DPM', enterprise: 'Custom', enterpriseNote: 'Volume discounts' },
-      { name: 'Retention', free: '1 day', pro: '7 days', enterprise: 'Custom' },
+      { name: 'Retention', free: '7 days', pro: '30 days', enterprise: 'Custom' },
       { name: 'Concurrent Endpoints', free: '10', pro: '100', proNote: 'then $0.50/100 endpoints', enterprise: 'Custom' },
     ],
   },

--- a/src/app/services/hosting/page.jsx
+++ b/src/app/services/hosting/page.jsx
@@ -104,7 +104,7 @@ export default function HostingPage() {
                     <span className="text-irohPurple-500">✓</span>Negotiated bandwidth
                   </li>
                   <li className="flex items-center gap-2">
-                    <span className="text-irohPurple-500">✓</span>Early access to new features 
+                    <span className="text-irohPurple-500">✓</span>Client version locking &amp; diagnostics
                   </li>
                   <li className="flex items-center gap-2">
                     <span className="text-irohPurple-500">✓</span> Uptime SLAs available

--- a/src/app/services/hosting/page.jsx
+++ b/src/app/services/hosting/page.jsx
@@ -92,7 +92,7 @@ export default function HostingPage() {
                 <ul className="text-irohGray-600 dark:text-irohGray-300 space-y-2 mb-6">
 
                   <li className="flex items-center gap-2">
-                    <span className="text-irohPurple-500">✓</span>Authenticated by default&mdash;only your endpoints connect
+                    <span className="text-irohPurple-500">✓</span>Authenticated by default, so only your endpoints connect
                   </li>
                   <li className="flex items-center gap-2">
                     <span className="text-irohPurple-500">✓</span>Multi-region or multi-cloud deployment
@@ -138,7 +138,7 @@ export default function HostingPage() {
                 <h2 className="text-3xl font-bold mb-6">Relays</h2>
                 <p className="text-lg text-irohGray-600 dark:text-irohGray-300 mb-6 leading-relaxed">
                   Iroh uses QUIC for fast, reliable connections between peers. When a direct connection 
-                  isn&apos;t possible&mdash;due to firewalls, NAT, or network conditions&mdash;relays step in 
+                  isn&apos;t possible, due to firewalls, NAT, or network conditions, relays step in
                   to ensure data continues flowing.
                   <br></br>
 
@@ -149,7 +149,7 @@ export default function HostingPage() {
 
                 <h2 className="text-3xl font-bold mb-6">Authentication</h2>
                 <p className="text-lg text-irohGray-600 dark:text-irohGray-300 mb-6 leading-relaxed">
-                  Dedicated relays are authenticated by default&mdash;only your project&apos;s
+                  Dedicated relays are authenticated by default. Only your project&apos;s
                   endpoints can connect, using your API key. It&apos;s built in, with
                   nothing extra to wire up.
                   <br></br>

--- a/src/app/services/hosting/page.jsx
+++ b/src/app/services/hosting/page.jsx
@@ -92,6 +92,9 @@ export default function HostingPage() {
                 <ul className="text-irohGray-600 dark:text-irohGray-300 space-y-2 mb-6">
 
                   <li className="flex items-center gap-2">
+                    <span className="text-irohPurple-500">✓</span>Authenticated by default&mdash;only your endpoints connect
+                  </li>
+                  <li className="flex items-center gap-2">
                     <span className="text-irohPurple-500">✓</span>Multi-region or multi-cloud deployment
                   </li>
                   <li className="flex items-center gap-2">
@@ -144,15 +147,27 @@ export default function HostingPage() {
                   </Link> 
                 </p>
 
+                <h2 className="text-3xl font-bold mb-6">Authentication</h2>
+                <p className="text-lg text-irohGray-600 dark:text-irohGray-300 mb-6 leading-relaxed">
+                  Dedicated relays are authenticated by default&mdash;only your project&apos;s
+                  endpoints can connect, using your API key. It&apos;s built in, with
+                  nothing extra to wire up.
+                  <br></br>
+
+                  <Link href="https://docs.iroh.computer/concepts/relays#authentication" target="_blank" className="text-irohPurple-500 hover:underline">
+                  Read more.
+                  </Link>
+                </p>
+
                 <h2 className="text-3xl font-bold mb-6">DNS Discovery</h2>
                 <p className="text-lg text-irohGray-600 dark:text-irohGray-300 mb-6 leading-relaxed">
                   Iroh can use standard DNS servers to publish, discover, and resolve
                   EndpointIds. This allows clients to be discoverable globally.
-                  <br></br> 
-                  
+                  <br></br>
+
                   <Link href="https://docs.iroh.computer/concepts/discovery" target="_blank" className="text-irohPurple-500 hover:underline">
                   Read more.
-                  </Link> 
+                  </Link>
                 </p>
               </div>
               <div className="flex items-center justify-center">


### PR DESCRIPTION
## Summary

Dedicated relays from Iroh Services are now **authenticated by default** — only a project's own endpoints can connect, using the project's API key. This surfaces that on the hosting page.

## Changes

- **Cloud (dedicated relay) card** — adds a lead feature bullet: *"Authenticated by default—only your endpoints connect."*
- **"How Relays Work" section** — adds a short **Authentication** explainer alongside Relays and DNS Discovery, linking to `docs.iroh.computer/concepts/relays#authentication`.

The public relays card is unchanged (authentication is a dedicated/hosted feature). Framing is authentication on/off, consistent with the docs — no public/private language.

## Related

Pairs with the docs PR documenting relay authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)