### PR TITLE
Force light mode site-wide

### DIFF
--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -1,38 +1,13 @@
 'use client';
 
-import {createContext, useEffect} from 'react';
-import {ThemeProvider, useTheme} from 'next-themes';
-
-function ThemeWatcher() {
-  const {resolvedTheme, setTheme} = useTheme();
-
-  useEffect(() => {
-    const media = window.matchMedia('(prefers-color-scheme: dark)');
-
-    function onMediaChange() {
-      const systemTheme = media.matches ? 'dark' : 'light';
-      if (resolvedTheme === systemTheme) {
-        setTheme('system');
-      }
-    }
-
-    onMediaChange();
-    media.addEventListener('change', onMediaChange);
-
-    return () => {
-      media.removeEventListener('change', onMediaChange);
-    };
-  }, [resolvedTheme, setTheme]);
-
-  return null;
-}
+import {createContext} from 'react';
+import {ThemeProvider} from 'next-themes';
 
 export const AppContext = createContext({})
 
 export function Providers({ children }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
-      <ThemeWatcher />
+    <ThemeProvider attribute="class" forcedTheme="light" disableTransitionOnChange>
       {children}
     </ThemeProvider>
   );

--- a/src/components/BlogHeader.jsx
+++ b/src/components/BlogHeader.jsx
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 import {Button} from '@/components/Button';
 import {Logotype} from '@/components/Logotype';
 import {MobileSearch} from '@/components/Search';
-import {ThemeToggle} from '@/components/ThemeToggle';
 import {TopLevelNavItem, navItems} from '@/components/Header';
 import GithubStars from '@/components/GithubStars';
 
@@ -38,7 +37,6 @@ export default function BlogHeader() {
         <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />
         <div className="flex gap-4">
           <MobileSearch />
-          <ThemeToggle />
         </div>
         <div className="hidden min-[416px]:contents">
           <Button href="https://services.iroh.computer">Sign up</Button>

--- a/src/components/FooterMarketing.jsx
+++ b/src/components/FooterMarketing.jsx
@@ -2,7 +2,6 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 import Logo from "@/components/Logo";
-import { ThemeToggle } from './ThemeToggle';
 import { BlueskyIcon, DiscordIcon, GitHubIcon, MastodonIcon, TwitterIcon, YouTubeIcon } from './Footer';
 
 const navigation = {
@@ -123,7 +122,6 @@ export function FooterMarketing() {
         </div>
         <div className="mt-16 flex border-t border-white/10 pt-8 sm:mt-20 lg:mt-24">
           <p className="text-xs leading-5 text-gray-400 mr-auto">&copy; 2025 n0, inc.</p>
-          <ThemeToggle />
         </div>
       </div>
     </footer>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,7 +13,6 @@ import {
 } from '@/components/MobileNavigation';
 import {useMobileNavigationStore} from '@/components/MobileNavigation';
 import {MobileSearch, Search} from '@/components/Search';
-import {ThemeToggle} from '@/components/ThemeToggle';
 import GithubStars from './GithubStars';
 
 export const navItems = [
@@ -135,7 +134,6 @@ export const Header = forwardRef(function Header({className, sidebar = []}, ref)
         {/* <div className="hidden lg:block lg:h-5 lg:w-px lg:bg-zinc-900/10 lg:dark:bg-white/15" /> */}
         <div className="flex gap-4">
           <MobileSearch />
-          <ThemeToggle />
         </div>
         <div className="hidden min-[416px]:contents">
           <Button href="https://services.iroh.computer?utm_source=website&utm_content=nav-signup" variant="filled">Sign Up</Button>


### PR DESCRIPTION
## Summary

Make the website light mode all the time.

- `providers.jsx` — set next-themes `forcedTheme="light"` and drop the system-preference `ThemeWatcher` (the theme no longer follows the OS).
- Remove the now-inert `<ThemeToggle />` (and its import) from `Header.jsx`, `BlogHeader.jsx`, and `FooterMarketing.jsx`.

`dark:` utility classes remain in the markup but never apply, since the `dark` class is never added to `<html>`. The `ThemeToggle` component file is left in place (now unused) to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)