### PR TITLE
Remove "Chat with us" from homepage hero

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import { ArrowRightIcon } from '@heroicons/react/24/outline'
 import { Cpu } from 'lucide-react'
 
-import {ContactTrigger} from '@/components/ContactButton';
 import {FooterMarketing} from '@/components/FooterMarketing';
 import {HeaderSparse} from '@/components/HeaderSparse';
 import {HomeHero} from '@/components/HomeHero';
@@ -47,12 +46,6 @@ export default function Page() {
                     <br />peer-to-peer connections between devices</h3>
                   <div className='flex mt-3 gap-3'>
                     <a href="https://docs.iroh.computer/quickstart" className="my-4 p-3 px-4 transition bg-irohPurple-500 text-white dark:bg-irohGray-800 dark:text-irohPurple-500 uppercase hover:bg-irohPurple-600 dark:hover:bg-irohGray-700 hover:text-white plausible-event-name=Home+Hero+Start+Project+Click">Read the Docs</a>
-                    <ContactTrigger
-                      source="home-hero"
-                      className="my-4 p-3 px-4 transition border border-irohPurple-500 text-irohPurple-500 uppercase hover:bg-irohPurple-500 hover:text-white cursor-pointer"
-                    >
-                      Chat with us
-                    </ContactTrigger>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Removes the "Chat with us" button from the homepage hero, leaving "Read the Docs" as the hero CTA. Also drops the now-unused `ContactTrigger` import.

Scoped to the homepage only — the enterprise page's "Chat with us" CTAs are left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)