### PR TITLE
Switch relay pricing from monthly to hourly

### DIFF
--- a/src/app/pricing/page.jsx
+++ b/src/app/pricing/page.jsx
@@ -83,7 +83,7 @@ const featureSections = [
   {
     name: 'Hosting',
     features: [
-      { name: 'Relays', free: 'Public', freeNote: 'Multi-tenant', pro: 'Cloud', proNote: '$199/relay', enterprise: 'Custom' },
+      { name: 'Relays', free: 'Public', freeNote: 'Multi-tenant', pro: 'Cloud', proNote: '$0.27/relay/hour', enterprise: 'Custom' },
       { name: 'Connections per Relay', free: 'Variable', freeNote: 'Rate-limited', pro: '60k', enterprise: 'Custom' },
       { name: 'Multi-region', free: null, pro: true, enterprise: 'Custom' },
       { name: 'Multi-cloud', free: null, pro: null, enterprise: true },

--- a/src/app/services/hosting/page.jsx
+++ b/src/app/services/hosting/page.jsx
@@ -85,7 +85,7 @@ export default function HostingPage() {
               <div className="p-8 rounded-lg border border-irohPurple-500 bg-irohGray-100 dark:bg-irohGray-800">
                 <Server className="h-10 w-10 text-irohPurple-500 mb-4" />
                 <h3 className="text-xl font-bold mb-2">Cloud</h3>
-                <p className="text-2xl font-bold text-irohPurple-500 mb-3">$199<span className="text-base font-normal text-irohGray-500">/month and up</span></p>
+                <p className="text-2xl font-bold text-irohPurple-500 mb-3">$0.27<span className="text-base font-normal text-irohGray-500">/hour and up</span></p>
                 <p className="text-irohGray-600 dark:text-irohGray-300 mb-4">
                   For production applications ready to scale with low latency.
                 </p>

--- a/src/components/PricingCalculator.jsx
+++ b/src/components/PricingCalculator.jsx
@@ -7,7 +7,8 @@ const INCLUDED_ENDPOINTS = 100
 const INCLUDED_DPM = 10000
 const ENDPOINT_RATE = 0.50
 const METRICS_RATE = 1.49
-const RELAY_RATE = 199
+const RELAY_HOURLY_RATE = 0.27
+const HOURS_PER_MONTH = 730
 
 const relayOptions = [0, 1, 2, 3, 4, 5]
 const peakConnectionOptions = [100, 200, 300, 500, 1000, 2000, 5000, 10000]
@@ -63,7 +64,7 @@ export function PricingCalculator() {
   const connectionsCost = (extraConnections / 100) * ENDPOINT_RATE
   const extraDpm = Math.max(0, dpm - INCLUDED_DPM)
   const metricsCost = (extraDpm / 1000) * METRICS_RATE
-  const relayCost = relays * RELAY_RATE
+  const relayCost = relays * RELAY_HOURLY_RATE * HOURS_PER_MONTH
   const total = PRO_BASE + connectionsCost + metricsCost + relayCost
 
   return (
@@ -144,7 +145,7 @@ export function PricingCalculator() {
                   <span className="font-medium">{formatPrice(relayCost)}/mo</span>
                 </div>
                 <p className="text-sm text-irohGray-500 dark:text-irohGray-400 mt-0.5">
-                  {relays} &times; ${RELAY_RATE}/each
+                  {relays} &times; ${RELAY_HOURLY_RATE}/hour &times; {HOURS_PER_MONTH} hrs
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- Show dedicated relay pricing per hour instead of per month to align with other hosting services (and make the offering seem cheaper) it is also more accurate to how the relays are billed: $0.27/hour, derived from $199/month at the standard 730 hours/month (works out to ~$197/month)
- Pricing table Pro note now reads `$0.27/relay/hour` (was `$199/relay`)
- Hosting page Cloud relay card now reads `$0.27/hour and up` (was `$199/month and up`)
- Pricing calculator still estimates a monthly total; the relay line computes `relays × $0.27/hour × 730 hrs` and shows that math in the breakdown

## Note
The hourly rate was derived from the existing monthly price. If a different rate is intended, it's a one-line change to `RELAY_HOURLY_RATE` in `PricingCalculator.jsx` plus the two display strings.

Companion PR: https://github.com/n0-computer/svc/pull/889