### PR TITLE
FT-style typography for the blog + restore dark mode toggle

### DIFF
--- a/src/app/blog/page.jsx
+++ b/src/app/blog/page.jsx
@@ -14,7 +14,7 @@ export const metadata = {
 function Article({ post }) {
   return (
     <article className="px-5 sm:px-0 md:grid md:grid-cols-4 md:items-baseline">
-      <Card className="md:col-span-3">
+      <Card className="md:col-span-3 [&_h2]:font-display [&_h2]:font-medium [&_p]:font-georgia">
         <Card.Title href={`/blog/${post.slug}`}>
           {post.title}
         </Card.Title>
@@ -49,8 +49,8 @@ export default async function ArticlesIndex() {
       <BlogHeader />
       <div className='my-20 mx-auto max-w-2xl min-h-screen lg:mt-32'>
         <header className="max-w-2xl px-4 sm:px-0">
-          <h1 className="text-4xl font-space font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-4xl">Blog</h1>
-          <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">all things iroh &amp; development</p>
+          <h1 className="text-4xl font-display font-semibold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-4xl">Blog</h1>
+          <p className="mt-6 text-base font-georgia text-zinc-600 dark:text-zinc-400">all things iroh &amp; development</p>
         </header>
         <div className="mt-20 md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
           <div className="flex max-w-3xl flex-col space-y-16">

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -41,7 +41,7 @@ export default async function RootLayout({children}) {
         <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..700;1,6..72,400..700&family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet" />
       </head>
       <body className="flex min-h-full bg-white antialiased dark:bg-zinc-900 font-space">
         <Providers>

--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -1,13 +1,24 @@
 'use client';
 
 import {createContext} from 'react';
+import {usePathname} from 'next/navigation';
 import {ThemeProvider} from 'next-themes';
 
 export const AppContext = createContext({})
 
 export function Providers({ children }) {
+  // The site is forced to light mode everywhere except the blog, where the
+  // header exposes a theme toggle.
+  const pathname = usePathname();
+  const isBlog = pathname === '/blog' || pathname.startsWith('/blog/');
+
   return (
-    <ThemeProvider attribute="class" forcedTheme="light" disableTransitionOnChange>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      forcedTheme={isBlog ? undefined : 'light'}
+      disableTransitionOnChange
+    >
       {children}
     </ThemeProvider>
   );

--- a/src/components/BlogHeader.jsx
+++ b/src/components/BlogHeader.jsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import {Button} from '@/components/Button';
 import {Logotype} from '@/components/Logotype';
 import {MobileSearch} from '@/components/Search';
+import {ThemeToggle} from '@/components/ThemeToggle';
 import {TopLevelNavItem, navItems} from '@/components/Header';
 import GithubStars from '@/components/GithubStars';
 
@@ -37,6 +38,7 @@ export default function BlogHeader() {
         <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />
         <div className="flex gap-4">
           <MobileSearch />
+          <ThemeToggle />
         </div>
         <div className="hidden min-[416px]:contents">
           <Button href="https://services.iroh.computer">Sign up</Button>

--- a/src/components/BlogPostLayout.jsx
+++ b/src/components/BlogPostLayout.jsx
@@ -25,7 +25,7 @@ export function BlogPostLayout({ article, references = [], children }) {
             </div>
             <article>
               <header className="flex flex-col">
-                <h1 className="text-4xl font-space font-bold tracking-tight text-irohGray-900 dark:text-irohGray-100 sm:text-5xl">
+                <h1 className="text-4xl font-display font-semibold tracking-tight text-irohGray-900 dark:text-irohGray-100 sm:text-5xl">
                   {article.title}
                 </h1>
                 <span className='mt-1 text-base text-irohGray-400 dark:text-irohGray-500'>
@@ -35,7 +35,11 @@ export function BlogPostLayout({ article, references = [], children }) {
                   <span>{' '}by {article.author}</span>
                 </span>
               </header>
-              <Prose className="mt-8" data-mdx-content>
+              <Prose
+                className="mt-8 prose-headings:font-display prose-headings:font-semibold prose-headings:tracking-tight"
+                style={{fontFamily: "Georgia, 'Times New Roman', serif"}}
+                data-mdx-content
+              >
                 {children}
                 {references.length > 0 && (
                   <References references={references} />

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -30,7 +30,9 @@ export default {
       fontFamily: {
         'space': ['Space Grotesk', 'sans-serif'],
         'spaceMono': ['Space Mono', 'sans-serif'],
-        'koulen': 'var(--font-koulen-regular)'
+        'koulen': 'var(--font-koulen-regular)',
+        'display': ['Newsreader', 'Georgia', 'serif'],
+        'georgia': ['Georgia', 'Times New Roman', 'serif'],
       },
       boxShadow: {
         glow: '0 0 4px rgb(0 0 0 / 0.1)',


### PR DESCRIPTION
Gives the blog the typographic feel of [ft.com](https://www.ft.com/) and brings the dark mode toggle back to the blog header.

## Typography (blog only)

- **Headlines** (post titles, in-post headings, index page + card titles): [Newsreader](https://fonts.google.com/specimen/Newsreader), a news-oriented serif with display optical sizing — the closest Google Fonts analogue to FT's proprietary Financier Display. Semibold, tight tracking.
- **Article body + index teasers**: **Georgia**, which is what ft.com itself uses for body copy — system font, so no extra webfont weight.
- Metadata (dates, bylines, nav, buttons) stays **Space Grotesk**, mirroring FT's sans-serif UI font (MetricWeb).
- Code blocks unchanged (mono). The rest of the site is untouched — overrides are scoped to `BlogPostLayout`, `blog/page.jsx`, and a `style` override passed into `Prose`.

## Dark mode toggle

- Restores `<ThemeToggle />` in the blog header's top-right bar (removed in #462 when the site went forced-light).
- `Providers` now forces light mode only **outside** `/blog`: the marketing site stays light as decided in #462, while the blog follows the toggle and remembers the preference.

## Verified

- `npm run build` passes.
- Checked in-browser: post + index render Newsreader/Georgia in light and dark; toggling persists across blog pages; the home page remains forced-light (with unchanged typography) even with a dark preference saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)