### PR TITLE
Clarify the homepage for newcomers

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -42,8 +42,7 @@ export default function Page() {
                   <h1 className="z-50 text-5xl font-bold leading-tight">
                     IP addresses <span className="text-irohPurple-500">break,</span> dial keys instead
                   </h1>
-                  <h3 className="text-lg mt-3 leading-normal">Modular networking stack for direct,{' '}
-                    <br />peer-to-peer connections between devices</h3>
+                  <h3 className="text-lg mt-3 leading-normal">Add peer-to-peer connectivity to your app.</h3>
                   <div className='flex mt-3 gap-3'>
                     <a href="https://docs.iroh.computer/quickstart" className="my-4 p-3 px-4 transition bg-irohPurple-500 text-white dark:bg-irohGray-800 dark:text-irohPurple-500 uppercase hover:bg-irohPurple-600 dark:hover:bg-irohGray-700 hover:text-white plausible-event-name=Home+Hero+Start+Project+Click">Read the Docs</a>
                   </div>
@@ -66,9 +65,8 @@ export default function Page() {
                 Forever.
               </p>
               <p className='text-xl font-medium text-irohGray-600 dark:text-irohGray-400 mt-4 md:mt-2'>
-                Send data to any device running anywhere, big or small &mdash;
-                cloud servers, tablets, or embedded systems.
-                The core peer-to-peer technology is <a href="https://github.com/n0-computer/iroh" className='text-irohPurple-500 hover:underline'>open source</a> and built on open standards, so you&apos;re never locked in.
+                Connect devices anywhere: servers, mobile apps, agents, desktops, and embedded systems. No VPNs, user accounts, or proprietary networks.
+                The core peer-to-peer technology is <a href="https://github.com/n0-computer/iroh" className='text-irohPurple-500 hover:underline'>open source</a> and built on open standards, so you&apos;re never locked in: connect over our free community <a href="https://docs.iroh.computer/concepts/relays" className='text-irohPurple-500 hover:underline'>relays</a>, self-host your own, or let us <a href="/pricing" className='text-irohPurple-500 hover:underline'>run them for you</a>, and switch between them whenever you want.
               </p>
             </div>
           </section>
@@ -170,7 +168,10 @@ export default function Page() {
                 <p className='mt-4 text-xl font-medium text-irohGray-600 dark:text-irohGray-400'>
                   iroh provides opt-in
                   <a href="https://docs.iroh.computer/iroh-services/metrics" className="text-irohPurple-500 hover:underline"> observability</a> and
-                  <a href="https://docs.iroh.computer/iroh-services/net-diagnostics/quickstart" className="text-irohPurple-500 hover:underline"> network diagnostics</a> &mdash; track connection health and throughput across all your devices and services.
+                  <a href="https://docs.iroh.computer/iroh-services/net-diagnostics/quickstart" className="text-irohPurple-500 hover:underline"> network diagnostics</a>. Track connection health and throughput across all your devices and services.
+                </p>
+                <p className='mt-4 text-xl font-medium text-irohGray-600 dark:text-irohGray-400'>
+                  You&apos;ll see how much of your traffic goes direct versus through a <a href="https://docs.iroh.computer/concepts/relays" className="text-irohPurple-500 hover:underline">relay</a>: a fallback server iroh uses when two devices can&apos;t reach each other directly, always end-to-end encrypted. <a href="/pricing" className="text-irohPurple-500 hover:underline">Compare plans</a>.
                 </p>
                 <Link href='https://services.iroh.computer/' className='inline-block mt-6 text-irohPurple-500 plausible-event-name=Home+Start+Building+Click'>
                   Monitor your App <ArrowRightIcon className='inline-block w-5 h-5 ml-2 -mt-1' />


### PR DESCRIPTION
Reframes the homepage around what a newcomer actually asks  based on reader feedback that the page didn't explain the mental model, what relays are, or how the open-source/"never locked in" story squares with paid pricing.

### Changes (all in `src/app/page.jsx`)

- **Hero subhead** — lead with the value, *"Add peer-to-peer connectivity to your app."*, instead of the jargon-y "Modular networking stack for direct, peer-to-peer connections between devices."
- **"Never locked in" paragraph** — reconcile open-source with pricing by spelling out the three ways to run it: free community relays, self-host your own, or managed (links to `/pricing`). New device list: *"servers, mobile apps, agents, desktops, and embedded systems. No VPNs, user accounts, or proprietary networks."*
- **Monitor section** — explain what a relay actually is (a fallback server, always end-to-end encrypted), tied to the direct-vs-relayed traffic the dashboard already surfaces.
