### PR TITLE
Esp32 blog post fixes

### DIFF
--- a/src/app/blog/an-iroh-powered-smart-fan/page.mdx
+++ b/src/app/blog/an-iroh-powered-smart-fan/page.mdx
@@ -28,7 +28,7 @@ export const metadata = {
 
 export default (props) => <BlogPostLayout article={post} {...props} />
 
-If you live in Europe you are probably suffering through a heat wave right now. Let's do something to bring back some chill, using iroh.
+If you live in ~Europe~ the northern hemisphere, you are probably suffering through a heat wave right now. Let's do something to bring back some chill, using iroh.
 
 The [previous ESP32 examples][esp32-examples] demonstrated echo protocols. But  typically ESP32s are used for more than just echoing data; you use an ESP32 as a cheap means to read sensors and drive actuators.
 

--- a/src/app/blog/an-iroh-powered-smart-fan/page.mdx
+++ b/src/app/blog/an-iroh-powered-smart-fan/page.mdx
@@ -37,7 +37,9 @@ So we are going to write a very simple end-to-end example using an ESP32 to meas
 As the base, we are going to use an [ESP32-WROVER devkit](https://store.freenove.com/products/fnk0047) with 4 MiB of [PSRAM][psram], so we have all of iroh's networking capabilities available, including a relay connection, and remote control it from anywhere in the world. You can also use a M5StickC-Plus2, but you will have to adapt the GPIO pins.
 
 <Note>
-If all you have is an ESP32 without PSRAM, you can still use iroh. But you need to disable the relay connection and tweak QUIC buffers so we don't run out of memory. Use an appropriate example from [iroh-esp32-examples][esp32-examples] as base.
+If you have another devkit such as an [ESP32-S3](https://store.freenove.com/products/fnk0084) *with* PSRAM, you should be able to run the examples with small config tweaks.
+
+If all you have is an ESP32 *without* PSRAM, you can still use iroh. But you need to disable the relay connection and tweak QUIC buffers so we don't run out of memory. Use an appropriate example from [iroh-esp32-examples][esp32-examples] as base.
 </Note>
 
 # Basic setup


### PR DESCRIPTION
- Add "the northern hemisphere" instead of Europe. It is hot in the US as well.

- Add remarks about the ESP32-S3 devkits. They should work just fine as well, I just don't have one here.